### PR TITLE
refactor:(router): create correct RESTful routes

### DIFF
--- a/src/Route/index.js
+++ b/src/Route/index.js
@@ -232,20 +232,16 @@ Route.resolve = function (urlPath, verb, host) {
  * @public
  */
 Route.resource = function (resourceName, handler) {
-  /**
-   * avoiding multiple / when route itself is a base
-   * route.
-   * @type {String}
-   */
+  let resourceUrl = resourceName.replace('.', '/')
 
-  Route.get(resourceName, `${handler}.index`).as(`${resourceName}.index`)
-  Route.get(`${resourceName}/:id`, `${handler}.show`).as(`${resourceName}.show`)
-  Route.get(`${resourceName}/create`, `${handler}.create`).as(`${resourceName}.create`)
-  Route.get(`${resourceName}/:id/edit`, `${handler}.edit`).as(`${resourceName}.edit`)
-  Route.post(resourceName, `${handler}.store`).as(`${resourceName}.store`)
-  Route.put(`${resourceName}/:id`, `${handler}.update`).as(`${resourceName}.update`)
-  Route.patch(`${resourceName}/:id`, `${handler}.update`)
-  Route.delete(`${resourceName}/:id`, `${handler}.destroy`).as(`${resourceName}.destroy`)
+  Route.get(resourceUrl, `${handler}.index`).as(`${resourceName}.index`)
+  Route.get(`${resourceUrl}/:id`, `${handler}.show`).as(`${resourceName}.show`)
+  Route.get(`${resourceUrl}/create`, `${handler}.create`).as(`${resourceName}.create`)
+  Route.get(`${resourceUrl}/:id/edit`, `${handler}.edit`).as(`${resourceName}.edit`)
+  Route.post(resourceUrl, `${handler}.store`).as(`${resourceName}.store`)
+  Route.put(`${resourceUrl}/:id`, `${handler}.update`).as(`${resourceName}.update`)
+  Route.patch(`${resourceUrl}/:id`, `${handler}.update`)
+  Route.delete(`${resourceUrl}/:id`, `${handler}.destroy`).as(`${resourceName}.destroy`)
 }
 
 /**

--- a/src/Route/index.js
+++ b/src/Route/index.js
@@ -227,24 +227,25 @@ Route.resolve = function (urlPath, verb, host) {
 /**
  * @description creates a resource of routes based out of conventions
  * @method resource
- * @param  {String} pattern
+ * @param  {String} resourceName
  * @param  {String} handler
  * @public
  */
-Route.resource = function (pattern, handler) {
+Route.resource = function (resourceName, handler) {
   /**
    * avoiding multiple / when route itself is a base
    * route.
    * @type {String}
    */
-  const seperator = pattern === '/' ? '' : '/'
 
-  Route.options(pattern, '')
-  Route.get(pattern, `${handler}.index`)
-  Route.post(pattern, `${handler}.store`)
-  Route.get(`${pattern}${seperator}:id`, `${handler}.show`)
-  Route.put(`${pattern}${seperator}:id`, `${handler}.update`)
-  Route.delete(`${pattern}${seperator}:id`, `${handler}.destroy`)
+  Route.get(resourceName, `${handler}.index`).as(`${resourceName}.index`)
+  Route.get(`${resourceName}/:id`, `${handler}.show`).as(`${resourceName}.show`)
+  Route.get(`${resourceName}/create`, `${handler}.create`).as(`${resourceName}.create`)
+  Route.get(`${resourceName}/:id/edit`, `${handler}.edit`).as(`${resourceName}.edit`)
+  Route.post(resourceName, `${handler}.store`).as(`${resourceName}.store`)
+  Route.put(`${resourceName}/:id`, `${handler}.update`).as(`${resourceName}.update`)
+  Route.patch(`${resourceName}/:id`, `${handler}.update`)
+  Route.delete(`${resourceName}/:id`, `${handler}.destroy`).as(`${resourceName}.destroy`)
 }
 
 /**

--- a/test/unit/route.spec.js
+++ b/test/unit/route.spec.js
@@ -108,6 +108,17 @@ describe('Route',function () {
       expect(routes[7].name).to.equal('users.destroy')
     })
 
+    it('should register nested resourceful routes', function() {
+      Route.resource('users.comments','SomeController')
+      const routes = Route.routes()
+      const verbs = _.fromPairs(_.map(routes, function (route) {
+        return [route.route + '-' + route.verb[0],true]
+      }))
+      expect(routes.length).to.equal(8)
+      expect(verbs['users/comments-GET']).not.to.equal(undefined)
+      expect(routes[0].name).to.equal('users.comments.index')
+    })
+
     it('should be able to name routes', function () {
       Route.any('/','SomeController.method').as('home')
       const routes = Route.routes()

--- a/test/unit/route.spec.js
+++ b/test/unit/route.spec.js
@@ -84,35 +84,29 @@ describe('Route',function () {
     })
 
     it('should register resourceful routes', function () {
-      Route.resource('/','SomeController')
+      Route.resource('users','SomeController')
       const routes = Route.routes()
       const verbs = _.fromPairs(_.map(routes, function (route) {
         return [route.route + '-' + route.verb[0],true]
       }))
-      expect(routes.length).to.equal(6)
-      expect(verbs['/-OPTIONS']).not.to.equal(undefined)
-      expect(verbs['/-GET']).not.to.equal(undefined)
-      expect(verbs['/-POST']).not.to.equal(undefined)
-      expect(verbs['/:id-GET']).not.to.equal(undefined)
-      expect(verbs['/:id-PUT']).not.to.equal(undefined)
-      expect(verbs['/:id-DELETE']).not.to.equal(undefined)
-    })
+      expect(routes.length).to.equal(8)
+      expect(verbs['users-GET']).not.to.equal(undefined)
+      expect(verbs['users/:id-GET']).not.to.equal(undefined)
+      expect(verbs['users/create-GET']).not.to.equal(undefined)
+      expect(verbs['users/:id/edit-GET']).not.to.equal(undefined)
+      expect(verbs['users-POST']).not.to.equal(undefined)
+      expect(verbs['users/:id-PUT']).not.to.equal(undefined)
+      expect(verbs['users/:id-PATCH']).not.to.equal(undefined)
+      expect(verbs['users/:id-DELETE']).not.to.equal(undefined)
 
-    it('should register resourceful routes when base route is not /', function () {
-      Route.resource('/admin','SomeController')
-      const routes = Route.routes()
-      const verbs = _.fromPairs(_.map(routes, function (route) {
-        return [route.route + '-' + route.verb[0],true]
-      }))
-      expect(routes.length).to.equal(6)
-      expect(verbs['/admin-OPTIONS']).not.to.equal(undefined)
-      expect(verbs['/admin-GET']).not.to.equal(undefined)
-      expect(verbs['/admin-POST']).not.to.equal(undefined)
-      expect(verbs['/admin/:id-GET']).not.to.equal(undefined)
-      expect(verbs['/admin/:id-PUT']).not.to.equal(undefined)
-      expect(verbs['/admin/:id-DELETE']).not.to.equal(undefined)
+      expect(routes[0].name).to.equal('users.index')
+      expect(routes[1].name).to.equal('users.show')
+      expect(routes[2].name).to.equal('users.create')
+      expect(routes[3].name).to.equal('users.edit')
+      expect(routes[4].name).to.equal('users.store')
+      expect(routes[5].name).to.equal('users.update')
+      expect(routes[7].name).to.equal('users.destroy')
     })
-
 
     it('should be able to name routes', function () {
       Route.any('/','SomeController.method').as('home')
@@ -172,20 +166,21 @@ describe('Route',function () {
 
     it('should prefix all resourceful routes under a group', function () {
       Route.group('admin',function () {
-        Route.resource('/','SomeController')
-      }).prefix('/v1')
+        Route.resource('users','SomeController')
+      }).prefix('/v1/')
       const routes = Route.routes()
       const verbs = _.fromPairs(_.map(routes, function (route) {
         return [route.route + '-' + route.verb[0],true]
       }))
-      expect(routes.length).to.equal(6)
-      expect(verbs['/v1-OPTIONS']).not.to.equal(undefined)
-      expect(verbs['/v1-GET']).not.to.equal(undefined)
-      expect(verbs['/v1-POST']).not.to.equal(undefined)
-      expect(verbs['/v1/:id-GET']).not.to.equal(undefined)
-      expect(verbs['/v1/:id-PUT']).not.to.equal(undefined)
-      expect(verbs['/v1/:id-DELETE']).not.to.equal(undefined)
-
+      expect(routes.length).to.equal(8)
+      expect(verbs['/v1/users-GET']).not.to.equal(undefined)
+      expect(verbs['/v1/users/create-GET']).not.to.equal(undefined)
+      expect(verbs['/v1/users-POST']).not.to.equal(undefined)
+      expect(verbs['/v1/users/:id-GET']).not.to.equal(undefined)
+      expect(verbs['/v1/users/:id/edit-GET']).not.to.equal(undefined)
+      expect(verbs['/v1/users/:id-PUT']).not.to.equal(undefined)
+      expect(verbs['/v1/users/:id-PATCH']).not.to.equal(undefined)
+      expect(verbs['/v1/users/:id-DELETE']).not.to.equal(undefined)
     })
 
     it('should be able to define subdomain for a given route', function () {


### PR DESCRIPTION
According to other frameworks (like [RoR](http://guides.rubyonrails.org/routing.html#resource-routing-the-rails-default) or [Laravel](https://laravel.com/docs/5.2/controllers#restful-resource-controllers)), our method doesn't work the same. It would be better if we have an identical API for other developers.

--
:heavy_exclamation_mark: **ChangeLogs**

* Add 2 new routes generated with `Route.resource()`.
```javascript,line-numbers
// Routes used to send the view
Route.get(`${resourceName}/create`, `${handler}.create`).as(`${resourceName}.create`)
Route.get(`${resourceName}/:id/edit`, `${handler}.edit`).as(`${resourceName}.edit`)
```

* Named by default generate routes.
* Remove the `OPTIONS` route.
* Need to pass a resource name in the first parameter (e.g: `users`, `comments`, `posts`, ...)

--

:fire: **BREAKING CHANGE**

* This commit breaks `Route.resource()` method.