### PR TITLE
Fix JSDoc in View core

### DIFF
--- a/src/View/index.js
+++ b/src/View/index.js
@@ -32,7 +32,7 @@ class View {
   /**
    * compile a view with give template and data
    *
-   * @param  {String} template_path
+   * @param  {String} templatePath
    * @param  {Object} [data]
    * @return {Promise}
    *
@@ -95,7 +95,7 @@ class View {
    * add a global method to views
    *
    * @param  {String} name
-   * @param  {Mixed} value
+   * @param  {*} value
    *
    * @example
    * View.global('key', value)


### PR DESCRIPTION
* Error in param name `templatePath ` was fixed;
* Right declaration `*` for any (mixed) param type in JSDoc: http://usejsdoc.org/tags-param.html#names-types-and-descriptions;