### PR TITLE
Add initialization vector to Encryption

### DIFF
--- a/src/Encryption/index.js
+++ b/src/Encryption/index.js
@@ -48,7 +48,7 @@ class Encryption {
 
     let iv = crypto.randomBytes(this.getIvSize())
 
-    let cipher = crypto.createCipheriv(this.algorithm, this.appKey, iv)
+    const cipher = crypto.createCipheriv(this.algorithm, this.appKey, iv)
     value = cipher.update(value, encoding, 'base64')
     value += cipher.final('base64')
 
@@ -59,8 +59,8 @@ class Encryption {
     // Once we have the encrypted value we will go ahead base64_encode the input
     // vector and create the MAC for the encrypted value so we can verify its
     // authenticity. Then, we'll JSON encode the data in a "payload" array.
-    let mac = this.hash(iv = this.base64Encode(iv), value)
-    let json = JSON.stringify({iv: iv, value: value, mac: mac})
+    const mac = this.hash(iv = this.base64Encode(iv), value)
+    const json = JSON.stringify({iv: iv, value: value, mac: mac})
     return this.base64Encode(json)
   }
 
@@ -80,10 +80,10 @@ class Encryption {
     encoding = encoding || 'utf8'
     payload = this.getJsonPayload(payload)
 
-    let iv = this.base64Decode(payload.iv, true)
+    const iv = this.base64Decode(payload.iv, true)
 
-    let decipher = crypto.createDecipheriv(this.algorithm, this.appKey, iv)
-    var decrypted = decipher.update(payload.value, 'base64', encoding)
+    const decipher = crypto.createDecipheriv(this.algorithm, this.appKey, iv)
+    let decrypted = decipher.update(payload.value, 'base64', encoding)
     decrypted += decipher.final(encoding)
 
     if (!decrypted) {
@@ -176,8 +176,8 @@ class Encryption {
    * @return {Boolean}
    */
   validMac (payload) {
-    let bytes = crypto.randomBytes(this.getIvSize())
-    let calcMac = this.hashHmac('sha256', this.hash(payload.iv, payload.value), bytes)
+    const bytes = crypto.randomBytes(this.getIvSize())
+    const calcMac = this.hashHmac('sha256', this.hash(payload.iv, payload.value), bytes)
     return this.hashHmac('sha256', payload.mac, bytes) === calcMac
   }
 

--- a/src/Encryption/index.js
+++ b/src/Encryption/index.js
@@ -110,7 +110,12 @@ class Encryption {
    * @return {Mixed}
    */
   getJsonPayload (payload) {
-    payload = JSON.parse(this.base64Decode(payload))
+    const json = this.base64Decode(payload)
+    try {
+      payload = JSON.parse(json)
+    } catch (e) {
+      throw new Error('The payload is not an json object.')
+    }
     // If the payload is not valid JSON or does not have the proper keys set we will
     // assume it is invalid and bail out of the routine since we will not be able
     // to decrypt the given value. We'll also check the MAC for this encryption.

--- a/src/Encryption/index.js
+++ b/src/Encryption/index.js
@@ -45,9 +45,23 @@ class Encryption {
    */
   encrypt (value, encoding) {
     encoding = encoding || 'utf8'
-    const cipher = crypto.createCipher(this.algorithm, this.appKey)
-    cipher.update(value, encoding, 'hex')
-    return cipher.final('hex')
+
+    let iv = crypto.randomBytes(this.getIvSize())
+
+    let cipher = crypto.createCipheriv(this.algorithm, this.appKey, iv)
+    value = cipher.update(value, encoding, 'base64')
+    value += cipher.final('base64')
+
+    if (!value) {
+      throw new Error('Could not encrypt the data.')
+    }
+
+    // Once we have the encrypted value we will go ahead base64_encode the input
+    // vector and create the MAC for the encrypted value so we can verify its
+    // authenticity. Then, we'll JSON encode the data in a "payload" array.
+    let mac = this.hash(iv = this.base64Encode(iv), value)
+    let json = JSON.stringify({iv: iv, value: value, mac: mac})
+    return this.base64Encode(json)
   }
 
   /**
@@ -62,11 +76,118 @@ class Encryption {
    *
    * @public
    */
-  decrypt (value, encoding) {
+  decrypt (payload, encoding) {
     encoding = encoding || 'utf8'
-    const decipher = crypto.createDecipher(this.algorithm, this.appKey)
-    decipher.update(value, 'hex', encoding)
-    return decipher.final(encoding)
+    payload = this.getJsonPayload(payload)
+
+    let iv = this.base64Decode(payload.iv, true)
+
+    let decipher = crypto.createDecipheriv(this.algorithm, this.appKey, iv)
+    var decrypted = decipher.update(payload.value, 'base64', encoding)
+    decrypted += decipher.final(encoding)
+
+    if (!decrypted) {
+      throw new Error('Could not decrypt the data.')
+    }
+    return decrypted
+  }
+
+  /**
+   * get the JSON object from the given payload
+   *
+   * @param  {String} payload
+   * @return {Mixed}
+   */
+  getJsonPayload (payload) {
+    payload = JSON.parse(this.base64Decode(payload))
+    // If the payload is not valid JSON or does not have the proper keys set we will
+    // assume it is invalid and bail out of the routine since we will not be able
+    // to decrypt the given value. We'll also check the MAC for this encryption.
+    if (!payload || this.invalidPayload(payload)) {
+      throw new Error('The payload is invalid.')
+    }
+    if (!this.validMac(payload)) {
+      throw new Error('The MAC is invalid.')
+    }
+    return payload
+  }
+
+  /**
+   * Create a MAC for the given value
+   *
+   * @param  {String} iv
+   * @param  {String} value
+   * @return {String}
+   */
+  hash (iv, value) {
+    return this.hashHmac('sha256', iv + value, this.appKey)
+  }
+
+  /**
+   * Generate a keyed hash value using the HMAC method
+   *
+   * @param  {String} algo
+   * @param  {String} data
+   * @param  {String} key
+   * @return {String}
+   */
+  hashHmac (algo, data, key) {
+    return crypto.createHmac(algo, key).update(data).digest('hex')
+  }
+
+  /**
+   * returns encoded base64 string
+   *
+   * @param  {String} unencoded
+   * @return {String}
+   */
+  base64Encode (unencoded) {
+    return new Buffer(unencoded || '').toString('base64')
+  }
+
+  /**
+   * returns decoded base64 string/buffer
+   *
+   * @param  {String} encoded
+   * @param  {Boolean} raw
+   * @return {Mixed}
+   */
+  base64Decode (encoded, raw) {
+    if (raw) {
+      return new Buffer(encoded || '', 'base64')
+    }
+    return new Buffer(encoded || '', 'base64').toString('utf8')
+  }
+
+  /**
+   * Verify that the encryption payload is valid.
+   *
+   * @param  {Mixed} data
+   * @return {Boolean}
+   */
+  invalidPayload (data) {
+    return typeof data !== 'object' || !data.hasOwnProperty('iv') || !data.hasOwnProperty('value') || !data.hasOwnProperty('mac')
+  }
+
+  /**
+   * Determine if the MAC for the given payload is valid
+   *
+   * @param  object payload
+   * @return {Boolean}
+   */
+  validMac (payload) {
+    let bytes = crypto.randomBytes(this.getIvSize())
+    let calcMac = this.hashHmac('sha256', this.hash(payload.iv, payload.value), bytes)
+    return this.hashHmac('sha256', payload.mac, bytes) === calcMac
+  }
+
+  /**
+   * Get the IV size for the cipher
+   *
+   * @return {Integer}
+   */
+  getIvSize () {
+    return 16
   }
 
 }

--- a/src/Encryption/index.js
+++ b/src/Encryption/index.js
@@ -14,6 +14,8 @@ const crypto = require('crypto')
 /**
  * Encrypt and decrypt values using nodeJs crypto, make
  * sure to set APP_KEY inside .env file.
+ *
+ * Not compatible with Laravel because they use serialize()/unserialize()
  * @class
  */
 class Encryption {
@@ -22,13 +24,22 @@ class Encryption {
     this.appKey = Config.get('app.appKey')
     this.algorithm = Config.get('app.encryption.algorithm', 'aes-256-cbc')
 
-    /**
-     * throwing error when APP_KEY is not defined as encryption
-     * does not make sense without a key
-     */
-    if (!this.appKey) {
-      throw new Error('Encryption cannot work without application key. Define appKey inside app config')
+    if (!this.supported(this.appKey, this.algorithm)) {
+      throw new Error('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.')
     }
+  }
+
+  /**
+   * Determine if the given key and cipher combination is valid.
+   *
+   * @param  {String}  key
+   * @param  {String}  cipher
+   * @return {Boolean}
+   */
+  supported (key, cipher) {
+    key = key || ''
+    cipher = cipher || ''
+    return (cipher.toLowerCase() === 'aes-128-cbc' && key.length === 16) || (cipher.toLowerCase() === 'aes-256-cbc' && key.length === 32)
   }
 
   /**

--- a/test/unit/encryption.spec.js
+++ b/test/unit/encryption.spec.js
@@ -10,15 +10,20 @@ const Encryption = require('../../src/Encryption')
 const chai = require('chai')
 const crypto = require('crypto')
 const expect = chai.expect
+let config
 let encryption
 
-const Config = {
-  get: function (key) {
+class Config {
+  constructor (key, algorithm) {
+    this.key = key
+    this.algorithm = algorithm || 'aes-256-cbc'
+  }
+  get (key) {
     if(key === 'app.appKey'){
-      return 'bubblegum'
+      return this.key
     }
     if(key === 'app.encryption.algorithm'){
-      return 'aes-256-cbc'
+      return this.algorithm
     }
   }
 }
@@ -26,34 +31,114 @@ const Config = {
 describe('Encryption', function() {
 
   before(function () {
-    encryption = new Encryption(Config)
+    config = new Config('a'.repeat(32), 'aes-256-cbc')
+    encryption = new Encryption(config)
   })
 
   it('should throw error when APP_KEY is not defined', function () {
     const fn = function () {
-      return new Encryption({get: function () {}})
+      return new Encryption(new Config())
     }
-    expect(fn).to.throw(/Encryption cannot work without application key/i)
+    expect(fn).to.throw(/The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths\./i)
   })
 
-  it('should encryption values using defined algorithm', function () {
-    const cipher = crypto.createCipher(Config.get('app.encryption.algorithm'),Config.get('app.appKey'))
-    cipher.update('virk')
-    const encrypted = encryption.encrypt('virk')
-    expect(encrypted).to.equal(cipher.final('hex'))
+  it('should throw error when APP_KEY to long', function () {
+    const fn = function () {
+      return new Encryption(new Config('a'.repeat(32), 'aes-128-cbc'))
+    }
+    expect(fn).to.throw(/The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths\./i)
+  })
+
+  it('should throw error when APP_KEY is wrong', function () {
+    const fn = function () {
+      return new Encryption(new Config('a'.repeat(5), 'aes-256-cbc'))
+    }
+    expect(fn).to.throw(/The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths\./i)
+  })
+
+  it('should throw error when cipher is unsupported', function () {
+    const fn = function () {
+      return new Encryption(new Config('a'.repeat(16), 'AES-256-CFB8'))
+    }
+    expect(fn).to.throw(/The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths\./i)
+  })
+
+  it('should throw error when APP_KEY length is wrong and cipher is unsupported', function () {
+    const fn = function () {
+      return new Encryption(new Config('a'.repeat(16), 'AES-256-CFB8'))
+    }
+    expect(fn).to.throw(/The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths\./i)
+  })
+
+  it('should calculate a correct sha256 hash', function () {
+    const hash = encryption.hash('These Aren\'t the Droids ', 'You\'re Looking For')
+    expect(hash).to.equal(crypto.createHmac('sha256', config.get('app.appKey')).update('These Aren\'t the Droids You\'re Looking For').digest('hex'))
+  })
+
+  it('should calculate a correct sha256 hash using HMAC method', function () {
+    const hmac = encryption.hashHmac('sha256', 'These Aren\'t the Droids You\'re Looking For', config.get('app.appKey'))
+    expect(hmac).to.equal(crypto.createHmac('sha256', config.get('app.appKey')).update('These Aren\'t the Droids You\'re Looking For').digest('hex'))
+  })
+
+  it('should encode base64', function () {
+    const base64 = encryption.base64Encode('These Aren\'t the Droids You\'re Looking For')
+    expect(base64).to.equal('VGhlc2UgQXJlbid0IHRoZSBEcm9pZHMgWW91J3JlIExvb2tpbmcgRm9y')
+  })
+
+  it('should decode base64', function () {
+    const plain = encryption.base64Decode('VGhlc2UgQXJlbid0IHRoZSBEcm9pZHMgWW91J3JlIExvb2tpbmcgRm9y')
+    expect(plain).to.equal('These Aren\'t the Droids You\'re Looking For')
+  })
+
+  it('should detect valid payload', function () {
+    const invalid = encryption.invalidPayload({iv:'', value:'', mac:''})
+    expect(invalid).to.equal(false)
+  })
+
+  it('should detect valid mac', function () {
+    const payload = {iv:'gD+wK78S1q4L3Vzgullp8Q==', value:'These Aren\'t the Droids You\'re Looking For', mac:'ffcfa6ced2727ba646467688e1f3ae0d38ccb7c5b4a9c6f9876d6d749100c2bd'}
+    const invalid = encryption.validMac(payload)
+    expect(invalid).to.equal(true)
+  })
+
+  it('should throw error when payload is invalid', function () {
+    const fn = function () {
+      return encryption.getJsonPayload('Int9Ig==')
+    }
+    expect(fn).to.throw(/The payload is invalid\./i)
+  })
+
+  it('should throw error when payload is not an json object', function () {
+    const fn = function () {
+      return encryption.getJsonPayload('foo')
+    }
+    expect(fn).to.throw(/The payload is not an json object\./i)
+  })
+
+  it('should throw error when mac is invalid', function () {
+    let iv = crypto.randomBytes(16)
+    const mac = encryption.hash(iv = encryption.base64Encode(iv), 'These Aren\'t the Droids You\'re Looking For')
+    const json = JSON.stringify({iv: iv, value: 'These Are the Droids You\'re Looking For', mac: mac})
+    const base64 = encryption.base64Encode(json)
+    const fn = function () {
+      return encryption.getJsonPayload(base64)
+    }
+    expect(fn).to.throw(/The MAC is invalid\./i)
   })
 
   it('should decrypt values using defined algorithm', function () {
-    const encrypted = encryption.encrypt('virk')
+    const encrypted = encryption.encrypt('These Aren\'t the Droids You\'re Looking For')
     const decrypted = encryption.decrypt(encrypted)
-    expect(decrypted).to.equal('virk')
+    expect(decrypted).to.equal('These Aren\'t the Droids You\'re Looking For')
   })
 
-  it('should throw error when decryption fails', function () {
+  it('should throw error with different keys', function () {
     const fn = function () {
-      return encryption.decrypt('foo')
+      const a = new Encryption(new Config('a'.repeat(32), 'aes-256-cbc'))
+      const b = new Encryption(new Config('b'.repeat(32), 'aes-256-cbc'))
+      console.log(b.decrypt(a.encrypt('These Aren\'t the Droids You\'re Looking For')))
     }
-    expect(fn).to.throw(/Bad input/)
+    expect(fn).to.throw(/The MAC is invalid\./i)
   })
 
-});
+})


### PR DESCRIPTION
The Encryption class didn't work properly, so i fixed it and implemented it like [Laravel](https://github.com/laravel/framework/blob/5.2/src/Illuminate/Encryption/Encrypter.php) did.
It now uses initialization vector for the encryption.
Unfortunately it's not compatible with Laravels encrypted data, because they use [serialize](https://github.com/laravel/framework/blob/5.2/src/Illuminate/Encryption/Encrypter.php#L66)/[unserialize](https://github.com/laravel/framework/blob/5.2/src/Illuminate/Encryption/Encrypter.php#L106).