### PR TITLE
'yield next' called in a global middleware does not wait for all processes in (Server) helpers.callRouteAction() 

### DIFF
--- a/src/Server/helpers.js
+++ b/src/Server/helpers.js
@@ -26,7 +26,7 @@ let helpers = exports = module.exports = {}
  * @return {void}
  */
 helpers.callRouteAction = function (resolvedRoute, request, response, middleware, appNamespace) {
-  co(function * () {
+  return co(function * () {
     /**
      * resolving route middleware if any, middleware.resolve tends
      * to throw errors bubbled by IoC container
@@ -63,7 +63,7 @@ helpers.callRouteAction = function (resolvedRoute, request, response, middleware
  * @public
  */
 helpers.respondRequest = function (middleware, request, response, finalHandler) {
-  co(function * () {
+  return co(function * () {
     /**
      * here we resolve all global middleware and compose
      * them

--- a/src/Server/index.js
+++ b/src/Server/index.js
@@ -40,8 +40,7 @@ class Server {
      * route action.
      */
     if (resolvedRoute.handler) {
-      helpers.callRouteAction(resolvedRoute, request, response, this.middleware, this.helpers.appNameSpace())
-      return
+      return helpers.callRouteAction(resolvedRoute, request, response, this.middleware, this.helpers.appNameSpace())
     }
 
     const error = new Error(`Route not found ${request.url()}`)
@@ -88,7 +87,7 @@ class Server {
     request._params = resolvedRoute.params
 
     const finalHandler = function * () {
-      self._finalHandler(resolvedRoute, request, response)
+      yield self._finalHandler(resolvedRoute, request, response)
     }
 
     if (method !== 'GET' && method !== 'HEAD') {


### PR DESCRIPTION
Hi, 

We are coming from Laravel (4.2) background and we are migrating to Node for our Frontend server. First of all, thanks for the beautiful framework which helps our migration easier. 

Sometimes we want to make a global middleware that mimics a global after-filter available in, for example, Laravel 4. That is, we need to wait until the route middlewares and the route controller have finished preparing the response. Currently, we see that 'yield next' called in global middleware does not wait until all processes called in (Server) helpers.callRouteAction() to be done. Therefore, this is our pull request. 

Let us know if we miss understanding something. Thanks.