### PR TITLE
chore(view): let us use . instead of / to define a view

### DIFF
--- a/src/View/loader.js
+++ b/src/View/loader.js
@@ -41,6 +41,7 @@ exports = module.exports = nunjucks.Loader.extend({
    * @public
    */
   getSource: function (name, callback) {
+    name = name.replace(/(\.(?!nunjucks))/g, '/')
     name = path.extname(name) === '.nunjucks' ? name : `${name}.nunjucks`
     const viewPath = path.resolve(this.viewsPath, name)
     const self = this

--- a/test/unit/app/views/extends.nunjucks
+++ b/test/unit/app/views/extends.nunjucks
@@ -1,0 +1,4 @@
+{% extends 'subviews.master' %}
+
+{% block content %} <h2> Hello world </h2> {% endblock %}
+

--- a/test/unit/app/views/include.nunjucks
+++ b/test/unit/app/views/include.nunjucks
@@ -1,0 +1,1 @@
+{% include 'subviews.index' %}

--- a/test/unit/app/views/subviews/index.nunjucks
+++ b/test/unit/app/views/subviews/index.nunjucks
@@ -1,0 +1,1 @@
+<h2> Hello world </h2>

--- a/test/unit/app/views/subviews/master.nunjucks
+++ b/test/unit/app/views/subviews/master.nunjucks
@@ -1,0 +1,2 @@
+{% block content %}
+{% endblock %}

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -54,6 +54,36 @@ describe('View',function () {
     expect(index.trim()).to.equal('<h2> Hello world </h2>')
   })
 
+  it('should make a nested view using a /', function * () {
+    const index = yield this.view.make('subviews/index')
+    expect(index.trim()).to.equal('<h2> Hello world </h2>')
+  })
+
+  it('should make a nested view using a / and the extension', function * () {
+    const index = yield this.view.make('subviews/index.nunjucks')
+    expect(index.trim()).to.equal('<h2> Hello world </h2>')
+  })
+
+  it('should make a nested view using a .', function * () {
+    const index = yield this.view.make('subviews.index')
+    expect(index.trim()).to.equal('<h2> Hello world </h2>')
+  })
+
+  it('should make a nested view using a . and the extension', function * () {
+    const index = yield this.view.make('subviews.index.nunjucks')
+    expect(index.trim()).to.equal('<h2> Hello world </h2>')
+  })
+
+  it('should include a view using a .', function * () {
+    const index = yield this.view.make('include')
+    expect(index.trim()).to.equal('<h2> Hello world </h2>')
+  })
+
+  it('should extends a view using a .', function * () {
+    const index = yield this.view.make('extends')
+    expect(index.trim()).to.equal('<h2> Hello world </h2>')
+  })
+
   it('should make use of route filter inside views', function * () {
     Route.get('/:id','ProfileController.show').as('profile')
     const profile = yield this.view.make('profile',{id:1})


### PR DESCRIPTION
Breaking Change Friendly :heavy_check_mark:

This PR allow us to use a . instead of a / to define a view.

Examples:
```javascript
// Routing
Route.on('/').render('frontend.pages.index')
```

```javascript
// Templating
{% extends 'frontend.layouts.app' %}

{% include 'frontend.partials.navbar' %}
```