### PR TITLE
chore(package): rollback cheerio version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "adonis-fold": "^3.0.1",
     "chai": "^3.3.0",
-    "cheerio": "^0.21.0",
+    "cheerio": "^0.20.0",
     "co-mocha": "^1.1.2",
     "co-supertest": "0.0.10",
     "coveralls": "^2.11.7",


### PR DESCRIPTION
The developer of Cheerio has unpublish the version 0.21.0.
We should remove this version from our package.json file.

More information: https://github.com/cheeriojs/cheerio/issues/872