### PR TITLE
feat: Make Server.listen() return the http.Server instance

### DIFF
--- a/src/Server/index.js
+++ b/src/Server/index.js
@@ -250,6 +250,7 @@ class Server {
    *
    * @param {String} host
    * @param {String} port
+   * @return {instance of http.Server}
    *
    * @example
    * Server.listen('localhost', 3333)
@@ -258,7 +259,7 @@ class Server {
    */
   listen (host, port) {
     this.log.info('serving app on %s:%s', host, port)
-    this.getInstance().listen(port, host)
+    return this.getInstance().listen(port, host)
   }
 
 }

--- a/test/unit/server.spec.js
+++ b/test/unit/server.spec.js
@@ -285,6 +285,12 @@ describe('Server', function () {
     expect(this.server.httpInstance).to.be.instanceOf(http.Server)
   })
 
+  it('should listen method returns the server instance', function * () {
+    const httpServer = this.server.listen('0.0.0.0', 8000)
+    expect(httpServer).to.be.instanceOf(http.Server)
+    expect(this.server.httpInstance).to.be.instanceOf(http.Server)
+  })
+
   it('should listen to server on a given port and host using listen method', function * () {
     Route.get('/', 'HomeController.index')
     this.server.listen('0.0.0.0', 8000)


### PR DESCRIPTION
Hi!

I only let the listen() method to return the server instance (like the official server.listen())

So we can do:
```js
let server = Server.listen(Env.get('HOST'), Env.get('PORT'))
// Use server with socket.io configuration...
```

I'm aware about `Server.getInstance()` but I wanted to know your point of view comparing to the official behaviour.

PS: I added the test associated to the feature