### PR TITLE
fix: Fix bug when using a namespace starting with App

### DIFF
--- a/src/Helpers/index.js
+++ b/src/Helpers/index.js
@@ -204,7 +204,7 @@ Helpers.appNameSpace = function () {
  */
 Helpers.makeNameSpace = function (baseNameSpace, toPath) {
   const appNameSpace = Helpers.appNameSpace()
-  if (toPath.startsWith(appNameSpace)) {
+  if (toPath.startsWith(`${appNameSpace}/`)) {
     return toPath
   }
   return path.normalize(`${appNameSpace}/${baseNameSpace}/${toPath}`)

--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -140,5 +140,10 @@ describe('Helpers', function () {
       const hook = Helpers.makeNameSpace('Model/Hooks', 'App/Model/Hooks/UserHook.validate')
       expect(hook).to.equal('App/Model/Hooks/UserHook.validate')
     })
+
+    it('should make complete namespace for a given namespace starting with  toPath is already a complete namespace', function () {
+      const hook = Helpers.makeNameSpace('Model/Hooks', 'Apple.validate')
+      expect(hook).to.equal('App/Model/Hooks/Apple.validate')
+    })
   })
 })


### PR DESCRIPTION
Hi,

## Bug reproduction
```js
// app/Http/Controllers
Route.get('*', 'AppleController.eat')
```
```js
// package.json
"autoload": {
  "App": "./app"
}
```

I get this error when I added a controller starting with App:

```
Cannot find module '/Users/Atinux/Projets/MyAdonisApp/appleController'
```

## Bug fix

I found the bug in the `Helpers.makeNameSpace()` method.

I replaced:
```js
toPath.startsWith(appNameSpace)
```

to

```js
toPath.startsWith(`${appNameSpace}/`)
```

So now it makes sure to verify that the namespace has a slash after.

I also added a test to verify any regression for this bug 🔥 