### PR TITLE
make server to be singleton

### DIFF
--- a/providers/ServerProvider.js
+++ b/providers/ServerProvider.js
@@ -11,7 +11,7 @@ const ServiceProvider = require('adonis-fold').ServiceProvider
 class ServerProvider extends ServiceProvider {
 
   * register () {
-    this.app.bind('Adonis/Src/Server', function (app) {
+    this.app.singleton('Adonis/Src/Server', function (app) {
       const Request = app.use('Adonis/Src/Request')
       const Response = app.use('Adonis/Src/Response')
       const Route = app.use('Adonis/Src/Route')


### PR DESCRIPTION
I think it better server to be singleton as server only need run once until it die.
and with this we can get server instance from anywhere.

if server provider using `bind` we will be hard to get server instance as every time we call `use('Adonis/Src/Server')`, server will be get new instance