### PR TITLE
Add delete method on File class

### DIFF
--- a/src/Exceptions/index.js
+++ b/src/Exceptions/index.js
@@ -76,6 +76,18 @@ class RuntimeException extends NE.RuntimeException {
   }
 
   /**
+   * this exception is raised when an operation is attempted
+   * on a file that has been deleted
+   *
+   * @param  {Number} [code=500]
+   *
+   * @return {Object}
+   */
+  static fileDeleted (code) {
+    return new this('The file has already been deleted', code || this.defaultErrorCode, 'E_FILE_DELETED')
+  }
+
+  /**
    * this exception is raised when encryption class is not
    * able to decrypt a given piece of data
    *


### PR DESCRIPTION
This pull request adds a delete method on the `File` class.

This is helpful for when files are uploaded to the server to be dealt with and you want to discard them afterwords without calling `fs.unlink` manually.