### PR TITLE
fix(view): fix label default attribute, use for instead of name

### DIFF
--- a/src/View/Form/index.js
+++ b/src/View/Form/index.js
@@ -242,7 +242,7 @@ class Form {
   label (name, value, attributes) {
     attributes = attributes || {}
     value = value || name
-    const labelAttributes = [`name="${name}"`].concat(this._makeHtmlAttributes(attributes))
+    const labelAttributes = [`for="${name}"`].concat(this._makeHtmlAttributes(attributes))
     return this.env.filters.safe(`<label ${labelAttributes.join(' ')}> ${value} </label>`)
   }
 

--- a/test/unit/view.form.spec.js
+++ b/test/unit/view.form.spec.js
@@ -91,12 +91,12 @@ describe('Form Helper', function () {
 
   it('should be able to create label', function () {
     const label = form.label('email', 'Enter your email address')
-    expect(label.val).to.equal('<label name="email"> Enter your email address </label>')
+    expect(label.val).to.equal('<label for="email"> Enter your email address </label>')
   })
 
   it('should be able to define extra attributes with label', function () {
     const label = form.label('email', 'Enter your email address', {class: 'flat'})
-    expect(label.val).to.equal('<label name="email" class="flat"> Enter your email address </label>')
+    expect(label.val).to.equal('<label for="email" class="flat"> Enter your email address </label>')
   })
 
   it('should create an input box using text method', function () {


### PR DESCRIPTION
Label does not have `name` attribute, it uses `for` attribute which needs to be the same as input id.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label