### PR TITLE
feat(log): add log service so you can log things to console and syslog

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "adonis-binding-resolver": "^1.0.1",
+    "ain2": "^2.0.0",
     "bcryptjs": "^2.3.0",
     "bytes": "^2.4.0",
     "cat-log": "^1.0.2",

--- a/providers/LogProvider.js
+++ b/providers/LogProvider.js
@@ -1,0 +1,22 @@
+'use strict'
+
+/**
+ * adonis-framework
+ * Copyright(c) 2015-2016 Harminder Virk
+ * MIT Licensed
+*/
+
+const ServiceProvider = require('adonis-fold').ServiceProvider
+
+class LogProvider extends ServiceProvider {
+
+  * register () {
+    this.app.singleton('Adonis/Src/Log', function (app) {
+      const Log = require('../src/Log')
+      const Config = app.use('Adonis/Src/Config')
+      return new Log(Config)
+    })
+  }
+}
+
+module.exports = LogProvider

--- a/src/Log/index.js
+++ b/src/Log/index.js
@@ -1,0 +1,133 @@
+'use strict'
+
+/**
+ * adonis-framework
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+const CatLog = require('cat-log')
+const Syslog = require('ain2')
+const CE = require('../Exceptions')
+
+/**
+ * Manage application logs and sends them to syslog.
+ */
+class Log {
+  constructor (Config) {
+    this.syslog = new Syslog(Config.get('app.syslog'))
+    this.log = new CatLog('adonis:framework', 'silly')
+  }
+
+  /**
+   * here we send log to syslog
+   *
+   * @param  {String}    handler
+   *
+   * @private
+   */
+  _sendToSyslog (type, message) {
+    const allowedTypes = ['log', 'info', 'warn', 'error', 'dir', 'time', 'trace', 'assert']
+
+    if (allowedTypes.indexOf(type) === -1) {
+      throw CE.InvalidArgumentException.invalidParameter('Invalid syslog log method type.')
+    }
+
+    this.syslog[type](message)
+  }
+
+  /**
+   * log to console and syslog with info method
+   *
+   * @param  {String} message - Message to send to log
+   *
+   * @example
+   * Log.info('Hey, this is info message for console and syslog')
+   *
+   * @public
+   */
+  info (message) {
+    this._sendToSyslog('info', message)
+    this.log.info(message)
+  }
+
+  /**
+   * log to console and syslog with warn method
+   *
+   * @param  {String} message - Message to send to log
+   *
+   * @example
+   * Log.warn('Hey, this is warn message for console and syslog')
+   *
+   * @public
+   */
+  warn (message) {
+    this._sendToSyslog('warn', message)
+    this.log.warn(message)
+  }
+
+  /**
+   * log to console and syslog with error method
+   *
+   * @param  {String} message - Message to send to log
+   *
+   * @example
+   * Log.error('Hey, this is error message for console and syslog')
+   *
+   * @public
+   */
+  error (message) {
+    this._sendToSyslog('error', message)
+    this.log.error(message)
+  }
+
+  /**
+   * log to console and syslog with debug method
+   *
+   * @param  {String} message - Message to send to log
+   *
+   * @example
+   * Log.debug('Hey, this is debug message for console and syslog')
+   *
+   * @public
+   */
+  debug (message) {
+    this._sendToSyslog('info', message)
+    this.log.debug(message)
+  }
+
+  /**
+   * log to console and syslog with verbose method
+   *
+   * @param  {String} message - Message to send to log
+   *
+   * @example
+   * Log.verbose('Hey, this is verbose message for console and syslog')
+   *
+   * @public
+   */
+  verbose (message) {
+    this._sendToSyslog('info', message)
+    this.log.verbose(message)
+  }
+
+  /**
+   * log to console and syslog with silly method
+   *
+   * @param  {String} message - Message to silly to log
+   *
+   * @example
+   * Log.silly('Hey, this is silly message for console and syslog')
+   *
+   * @public
+   */
+  silly (message) {
+    this._sendToSyslog('info', message)
+    this.log.silly(message)
+  }
+}
+
+module.exports = Log

--- a/test/unit/log.spec.js
+++ b/test/unit/log.spec.js
@@ -1,0 +1,71 @@
+'use strict'
+
+/**
+ * adonis-framework
+ * Copyright(c) 2015-2016 Harminder Virk
+ * MIT Licensed
+*/
+
+const Log = require('../../src/Log')
+const chai = require('chai')
+const sinon = require('sinon')
+const stdout = require('test-console').stderr
+const expect = chai.expect
+const Config = {
+  get: function (key) {
+    if (key === 'app.syslog') {
+      return {}
+    }
+  }
+}
+
+describe('Log', function () {
+  const methods = ['info', 'warn', 'error', 'debug', 'verbose', 'silly']
+
+  it(`should have methods ${methods.join(', ')}`, function () {
+    const log = new Log(Config)
+
+    methods.forEach((method) => {
+      expect(log).to.have.property(method)
+    })
+  })
+
+  it('should log messages to console', function () {
+    const log = new Log(Config)
+
+    methods.forEach((method) => {
+      const inspect = stdout.inspect()
+      let msg = ''
+      log[method](`This is test message for ${method}`)
+      inspect.restore()
+      inspect.output.forEach((item) => {
+        msg += item
+      })
+
+      expect(msg).to.contain(method)
+      expect(msg).to.contain('adonis:framework')
+      expect(msg).to.contain(`This is test message for ${method}`)
+    })
+  })
+
+  it('should throw if syslog method is not allowed', function () {
+    const log = new Log(Config)
+
+    try {
+      log._sendToSyslog('something', 'test message')
+    } catch (err) {
+      expect(err.message).to.equal('E_INVALID_PARAMETER: Invalid syslog log method type.')
+      expect(err.status).to.equal(500)
+    }
+  })
+
+  it('should log to syslog', function () {
+    const log = new Log(Config)
+    const inspect = stdout.inspect()
+
+    sinon.spy(log, '_sendToSyslog')
+    log.info('syslog test')
+    inspect.restore()
+    expect(log._sendToSyslog.calledOnce).to.equal(true)
+  })
+})


### PR DESCRIPTION
Log module should be used to log important things to console (using `cat-log`) and `syslog` (using `ain2` module from npm).

I can probably improve it, but I think this is enough for the first iteration.
Would need to propagate this module in other modules (instead of loading `cat-log` everywhere, we should load Log -> Helpers, Route, Server).