### PR TITLE
fix(routing): allow to prefix a group without a starting slash

### DIFF
--- a/src/Route/helpers.js
+++ b/src/Route/helpers.js
@@ -155,6 +155,7 @@ RouterHelper.addFormats = function (routes, formats, strict) {
  * @private
  */
 RouterHelper.prefixRoute = function (routes, prefix) {
+  prefix = prefix.startsWith('/') ? prefix : `/${prefix}`
   _.each(routes, function (route) {
     route.route = route.route === '/' ? prefix : prefix + route.route
     route.pattern = RouterHelper.makeRoutePattern(route.route)

--- a/test/unit/route.spec.js
+++ b/test/unit/route.spec.js
@@ -268,6 +268,15 @@ describe('Route', function () {
       expect(routes[0].route).to.equal('/v1')
     })
 
+    it('should be able to prefix routes inside a group without starting with a slash', function () {
+      Route.group('admin', function () {
+        Route.get('/', 'SomeController.method')
+      }).prefix('v1')
+      const routes = Route.routes()
+      expect(routes[0]).to.be.an('object')
+      expect(routes[0].route).to.equal('/v1')
+    })
+
     it('should prefix all resourceful routes under a group', function () {
       Route.group('v1', function () {
         Route.resource('admin', 'SomeController')


### PR DESCRIPTION
We should be able to prefix route's group without writing the first
slash.

Example:
```javascript
Route.group('v1', function () {
  // Some routes...
}).prefix('api/v1') // before it should be .prefix('/api/v1')
```

Closes: https://github.com/adonisjs/adonis-framework/issues/415
