### PR TITLE
add support for nested route groups

### DIFF
--- a/src/Route/index.js
+++ b/src/Route/index.js
@@ -371,7 +371,7 @@ Route.group = function (name, cb) {
   cb()
   groupChain.push(name)
   const groupRoutes = _.filter(routes, function (route) {
-    return groupChain.includes(route.group)
+    return _.includes(groupChain, route.group)
   })
   return new Group(groupRoutes)
 }

--- a/src/Route/index.js
+++ b/src/Route/index.js
@@ -23,6 +23,13 @@ const logger = new CatLog('adonis:framework')
 let routes = []
 
 /**
+ * chain of registered groups
+ * @type {Array}
+ * @private
+ */
+let groupChain = []
+
+/**
  * holding reference to active Group
  * @type {String}
  * @private
@@ -362,10 +369,10 @@ Route.middlewares = function () {
 Route.group = function (name, cb) {
   activeGroup = name
   cb()
+  groupChain.push(name)
   const groupRoutes = _.filter(routes, function (route) {
-    return route.group === activeGroup
+    return groupChain.includes(route.group)
   })
-  activeGroup = null
   return new Group(groupRoutes)
 }
 


### PR DESCRIPTION
This PR added support for nested groups:

```js
const Route = use('Route')

Route.group('api.v1', function () {
  Route.post('/users', 'UserController.store')
  Route.post('/token', 'SessionController.store')

  Route.group('authenticated', function () {
    Route.get('protected', 'ProtectedController')
  }).middleware('auth:jwt')
}).prefix('api/v1')
```