### PR TITLE
feat(event): allow to define multiple listeners at once

### DIFF
--- a/src/Event/index.js
+++ b/src/Event/index.js
@@ -242,9 +242,7 @@ class Event {
       name = null
     }
 
-    if (!Array.isArray(handlers)) {
-      handlers = [handlers]
-    }
+    handlers = _.isArray(handlers) ? handlers : [handlers]
 
     for (let handler of handlers) {
       resolver.validateBinding(handler)

--- a/src/Event/index.js
+++ b/src/Event/index.js
@@ -232,36 +232,43 @@ class Event {
    * adds a new event listen for a specific event
    *
    * @param  {String} event
-   * @param  {Function|String} handler
+   * @param  {Function|String|Array} handler
    *
    * @public
    */
-  on (event, name, handler) {
-    if (!handler) {
-      handler = name
+  on (event, name, handlers) {
+    if (!handlers) {
+      handlers = name
       name = null
     }
-    resolver.validateBinding(handler)
-    handler = this._resolveHandler(handler)
-    handler = this._makeHandler(handler)
-    if (name) {
-      this.namedListeners[name] = handler
+
+    if (!Array.isArray(handlers)) {
+      handlers = [handlers]
     }
 
-    /**
-     * if there is a limit define, go with the many
-     * method on the emitter
-     */
-    if (this.listenerLimit) {
-      this.emitter.many(event, this.listenerLimit, handler)
-      this.listenerLimit = null
-      return
-    }
+    for (let handler of handlers) {
+      resolver.validateBinding(handler)
+      handler = this._resolveHandler(handler)
+      handler = this._makeHandler(handler)
+      if (name) {
+        this.namedListeners[name] = handler
+      }
 
-    /**
-     * otherwise register normally
-     */
-    this.emitter.on(event, handler)
+      /**
+       * if there is a limit define, go with the many
+       * method on the emitter
+       */
+      if (this.listenerLimit) {
+        this.emitter.many(event, this.listenerLimit, handler)
+        this.listenerLimit = null
+        return
+      }
+
+      /**
+       * otherwise register normally
+       */
+      this.emitter.on(event, handler)
+    }
   }
 
   /**

--- a/test/unit/event.spec.js
+++ b/test/unit/event.spec.js
@@ -235,6 +235,30 @@ describe('Event', function () {
     expect(listeners.length).to.equal(1)
   })
 
+  it('should be able to define multiple listeners for one event', function (done) {
+    let count = 0
+    const event = new Event(Config, Helpers)
+    class Foo {
+      * bar (data) {
+        expect(data).deep.equal({foo: 'bar'})
+        count++
+      }
+
+      * baz (data) {
+        expect(data).deep.equal({foo: 'bar'})
+        count++
+      }
+    }
+    Ioc.bind('App/Listeners/Foo', function () {
+      return new Foo()
+    })
+
+    event.on('foo', ['Foo.bar', 'Foo.baz'])
+    event.fire('foo', {foo: 'bar'})
+    expect(count).to.equal(2)
+    done()
+  })
+
   it('should be able to get list of listeners for wildcard events', function () {
     const event = new Event(Config, Helpers)
     event.once('foo.bar', function () {})


### PR DESCRIPTION
This addition will let us define multiple listeners at once using an array.

**Before**
```javascript
Event.when('event', 'listener')
Event.when('event', 'listener')
Event.when('event', 'listener')
```

**After**
```javascript
Event.when('event', ['listener','listener','listener'])
```

<hr>

Closes: https://github.com/adonisjs/adonis-framework/issues/446