### PR TITLE
fix(routing): prioritise group level middleware

### DIFF
--- a/src/Route/helpers.js
+++ b/src/Route/helpers.js
@@ -116,7 +116,7 @@ RouterHelper.compileRouteToUrl = function (route, values) {
 RouterHelper.appendMiddleware = function (routes, middlewares) {
   if (_.isArray(routes)) {
     _.each(routes, function (route) {
-      route.middlewares = route.middlewares.concat(middlewares)
+      route.middlewares = _.concat(middlewares, route.middlewares)
     })
   } else {
     routes.middlewares = routes.middlewares.concat(middlewares)

--- a/test/unit/route.spec.js
+++ b/test/unit/route.spec.js
@@ -256,7 +256,7 @@ describe('Route', function () {
       expect(routes[0].group).to.equal('admin')
       expect(routes[0].middlewares).deep.equal(['auth'])
       expect(routes[1].group).to.equal('admin')
-      expect(routes[1].middlewares).deep.equal(['cors', 'auth'])
+      expect(routes[1].middlewares).deep.equal(['auth', 'cors'])
     })
 
     it('should be able to prefix routes inside a group', function () {
@@ -903,7 +903,7 @@ describe('Route', function () {
         Route.get('/', 'SomeController.method').middlewares(['cors'])
       }).middlewares(['auth'])
       const home = Route.resolve('/', 'GET')
-      expect(home.middlewares).deep.equal(['cors', 'auth'])
+      expect(home.middlewares).deep.equal(['auth', 'cors'])
     })
 
     it('should resolve routes with domains', function () {


### PR DESCRIPTION
Middleware(s) attached to route group should take **higher** precedence over middleware(s) defined on it's child routes.

**Example**
```
Route.group('project', () => {

  Route
    .get(':id/report', 'Project/ReportController.show')
    .middleware(['manager'])

}).prefix('project').middleware(['auth'])
```

**Current Effect**
- `manager` middleware is run first, checking if the _logged in user_ has the role of manager or not.
- But, it would fail because there is **no** authenticated user.

**Intended Effect (with the change)**
- `auth` middleware runs first, checking to see if the user is authenticated of not.
- On success, the flow is passed to `manager` middleware to check and see if the user is a "manager" or not.