### PR TITLE
Merge resource middleware

### DIFF
--- a/src/Route/Resource.js
+++ b/src/Route/Resource.js
@@ -256,7 +256,7 @@ class RouteResource extends Macroable {
    * Route
    *   .resource('user', 'UserController')
    *   .middleware(new Map([
-   *     ['auth', ['user.store', 'user.update', 'user.delete']]
+   *     [['user.store', 'user.update', 'user.delete'], 'auth']
    *   ]))
    * ```
    */

--- a/src/Route/Resource.js
+++ b/src/Route/Resource.js
@@ -261,38 +261,38 @@ class RouteResource extends Macroable {
    * ```
    */
   middleware (middleware) {
-    const middlewareMap = middleware instanceof Map ? {} : {
-      '*': _.castArray(middleware)
-    }
+    const middlewareMap = middleware instanceof Map ? middleware : new Map([
+      [['*'], _.castArray(middleware)]
+    ])
 
-    /**
-     * if middleware are defined as ES6 map, then we need
-     * to sort them as objects with key/value pair of
-     * single route names and an array of middleware
-     */
-    if (middleware instanceof Map === true) {
-      for (const [routeNames, middlewareList] of middleware) {
-        _.castArray(routeNames).forEach((name) => {
-          middlewareMap[name] = (middlewareMap[name] || []).concat(_.castArray(middlewareList))
+    const routesByName = this._getRoutesDict()
+    const routeNames = Object.keys(routesByName)
+
+    // go through list of the routes
+    // and replace '*' with the names of resource routes
+    const expandRoutesList = (list, name) => list.concat(name === '*' ? routeNames : name)
+
+    for (const [routeNamesList, middlewareList] of middlewareMap) {
+      _.castArray(routeNamesList)
+        .reduce(expandRoutesList, [])
+        .forEach((routeName) => {
+          routesByName[routeName].middleware(_.castArray(middlewareList))
         })
-      }
     }
-
-    const wildcardMiddleware = _.flatten(middlewareMap['*'] || [])
-
-    /**
-     * Finally apply the middleware to the routes
-     */
-    _.each(this._routes, (route) => {
-      const routeMiddleware = middlewareMap[route.routeInstance._name] || []
-      const middlewareHash = wildcardMiddleware.concat(_.flatten(routeMiddleware))
-
-      if (_.size(middlewareHash)) {
-        route.routeInstance.middleware(middlewareHash)
-      }
-    })
 
     return this
+  }
+
+  /**
+   * Return dictionary of _routes
+   *
+   * @private
+   */
+  _getRoutesDict () {
+    return this._routes.reduce(
+      (map, { routeInstance }) => Object.assign({}, map, { [routeInstance._name]: routeInstance }),
+      {}
+    )
   }
 
   /**

--- a/src/Route/Resource.js
+++ b/src/Route/Resource.js
@@ -278,11 +278,15 @@ class RouteResource extends Macroable {
       }
     }
 
+    const wildcardMiddleware = _.flatten(middlewareMap['*'] || [])
+
     /**
      * Finally apply the middleware to the routes
      */
     _.each(this._routes, (route) => {
-      const middlewareHash = _.flatten(middlewareMap['*'] || middlewareMap[route.routeInstance._name] || [])
+      const routeMiddleware = middlewareMap[route.routeInstance._name] || []
+      const middlewareHash = wildcardMiddleware.concat(_.flatten(routeMiddleware))
+
       if (_.size(middlewareHash)) {
         route.routeInstance.middleware(middlewareHash)
       }

--- a/test/unit/route.spec.js
+++ b/test/unit/route.spec.js
@@ -551,6 +551,24 @@ test.group('Route | Resource', (group) => {
       }
     })
   })
+
+  test('define resource middleware via ES6 maps containing wildcard middleware and middlewares for routes', (assert) => {
+    assert.plan(7)
+    const resource = new RouteResource('users', 'UsersController')
+
+    resource.middleware(new Map([
+      ['*', ['auth']],
+      ['users.store', ['addonValidator:User']]
+    ]))
+
+    RouteStore.list().forEach((route) => {
+      if (['users.store'].indexOf(route._name) > -1) {
+        assert.deepEqual(route._middleware, ['auth', 'addonValidator:User'])
+      } else {
+        assert.deepEqual(route._middleware, ['auth'])
+      }
+    })
+  })
 })
 
 test.group('Route | Manager', (group) => {

--- a/test/unit/route.spec.js
+++ b/test/unit/route.spec.js
@@ -557,13 +557,16 @@ test.group('Route | Resource', (group) => {
     const resource = new RouteResource('users', 'UsersController')
 
     resource.middleware(new Map([
+      ['users.destroy', ['role:admin']],
       ['*', ['auth']],
-      ['users.store', ['addonValidator:User']]
+      [['users.store', 'users.destroy'], ['addonValidator:User']]
     ]))
 
     RouteStore.list().forEach((route) => {
       if (['users.store'].indexOf(route._name) > -1) {
         assert.deepEqual(route._middleware, ['auth', 'addonValidator:User'])
+      } else if (['users.destroy'].indexOf(route._name) > -1) {
+        assert.deepEqual(route._middleware, ['role:admin', 'auth', 'addonValidator:User'])
       } else {
         assert.deepEqual(route._middleware, ['auth'])
       }


### PR DESCRIPTION
When a resource has defined global (wildcard) middleware and route-specific middleware only global middleware is used.

This PR introduces fix for this - when both, global and route-specific middlewares are defined they will be merged together.