### PR TITLE
Add namespace function to Route and Group

### DIFF
--- a/src/Route/Group.js
+++ b/src/Route/Group.js
@@ -60,6 +60,28 @@ class RouteGroup extends Macroable {
   }
 
   /**
+   * Namespace group of routes.
+   * Also see @ref('Route/namespace')
+   *
+   * @method namespace
+   *
+   * @param  {String} namespace
+   *
+   * @chainable
+   *
+   * @example
+   * ```js
+   * Route
+   *   .group()
+   *   .namespace('Admin')
+   * ```
+   */
+  namespace (namespace) {
+    this._routes.forEach((route) => route.namespace(namespace))
+    return this
+  }
+
+  /**
    * Add formats to a group of routes.
    * Also see @ref('Route/formats')
    *

--- a/src/Route/index.js
+++ b/src/Route/index.js
@@ -288,6 +288,32 @@ class Route extends Macroable {
   }
 
   /**
+   * Add a folder namespace to the route. Generally
+   * used by the Route group to namespace a bunch of
+   * routes that are all inside the same folder.
+   *
+   * @method namespace
+   *
+   * @param  {String} namespace
+   *
+   * @chainable
+   *
+   * @example
+   * ```
+   * Route
+   *   .get(...)
+   *   .namespace('Admin')
+   * ```
+   */
+  namespace (namespace) {
+    if (typeof (this.handler) !== 'string') return this
+
+    namespace = `${namespace.replace(/^\/|\/$/g, '')}/`
+    this.handler = `${namespace}${this.handler}`
+    return this
+  }
+
+  /**
    * Add middleware to the front of the route. The method is
    * same as `middleware` instead just prepends instead of
    * append.

--- a/test/unit/route.spec.js
+++ b/test/unit/route.spec.js
@@ -115,6 +115,25 @@ test.group('Route | Register', () => {
     assert.equal(route._regexp.exec('/api/v1/users')[0], '/api/v1/users')
   })
 
+  test('namespace route', (assert) => {
+    const route = new Route('/users', 'UserController')
+    route.namespace('Admin')
+    assert.equal(route.handler, 'Admin/UserController')
+  })
+
+  test('namespace route when there is extra backward slash', (assert) => {
+    const route = new Route('/users', 'UserController')
+    route.namespace('/Admin/')
+    assert.equal(route.handler, 'Admin/UserController')
+  })
+
+  test('namespace is not applied to functions', (assert) => {
+    const handler = function () {}
+    const route = new Route('/users', handler)
+    route.namespace('Admin')
+    assert.equal(route.handler, handler)
+  })
+
   test('define domain', (assert) => {
     const route = new Route('/users', function () {})
     route.domain('blog.adonisjs.com')
@@ -271,6 +290,15 @@ test.group('Route | Group', () => {
     group.prefix('api')
     assert.ok(route._regexp.test('/api'))
     assert.ok(userRoute._regexp.test('/api/user'))
+  })
+
+  test('namespace route via group', (assert) => {
+    const route = new Route('/', 'IndexController')
+    const userRoute = new Route('/user', 'UserController')
+    const group = new RouteGroup([route, userRoute])
+    group.namespace('Admin')
+    assert.equal(route.handler, 'Admin/IndexController')
+    assert.equal(userRoute.handler, 'Admin/UserController')
   })
 
   test('define domain via group', (assert) => {


### PR DESCRIPTION
This PR adds a `namespace` function to Route and Group.
This feature allows you to specify a folder on a group, so you do not have to repeat the same path on every route.

**Example:**
You have multiple Controller grouped inside folders: 
- app/Controller/Http/Api/v1/UserController.js
- app/Controller/Http/Api/v1/RoleController.js

With this PR you can simplify the route definition from this:
```js
Route.group(() => {
  Route.resource('/users', 'Api/v1/UserController')
  Route.resource('/roles', 'Api/v1/RoleController')
}).prefix('api/v1')
```
to this:
```js
Route.group(() => {
  Route.resource('/users', 'UserController')
  Route.resource('/roles', 'RoleController')
}).prefix('api/v1').namespace('Api/v1')
```