### PR TITLE
[Feature] Provide a way to use Argon instead of Bcrypt for hashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@adonisjs/fold": "^4.0.7",
     "@adonisjs/sink": "^1.0.16",
+    "argon2": "^0.17.3",
     "clear-require": "^2.0.0",
     "cookie-signature": "^1.1.0",
     "coveralls": "^3.0.0",

--- a/providers/AppProvider.js
+++ b/providers/AppProvider.js
@@ -161,10 +161,24 @@ class AppProvider extends ServiceProvider {
    * @private
    */
   _registerHash () {
-    this.app.singleton('Adonis/Src/Hash', () => {
-      return require('../src/Hash')
+    this.app.singleton('Adonis/Src/Hash', (app) => {
+      const HashFacade = require('../src/Hash/Facade')
+      return new HashFacade(app.use('Adonis/Src/Config'))
     })
     this.app.alias('Adonis/Src/Hash', 'Hash')
+  }
+
+  /**
+   * Register hash manager under `Adonis/Src/Hash` namespace
+   *
+   * @method _registerHashManager
+   *
+   * @return {void}
+   *
+   * @private
+   */
+  _registerHashManager () {
+    this.app.manager('Adonis/Src/Hash', require('../src/Hash/Manager'))
   }
 
   /**
@@ -295,6 +309,7 @@ class AppProvider extends ServiceProvider {
     this._registerLoggerManager()
     this._registerServer()
     this._registerHash()
+    this._registerHashManager()
     this._registerException()
     this._registerExceptionHandler()
     this._registerEncryption()

--- a/src/Hash/Drivers/Argon.js
+++ b/src/Hash/Drivers/Argon.js
@@ -14,11 +14,9 @@ const argon2 = require('argon2')
 /**
  * Hash plain values using [argon2](https://github.com/P-H-C/phc-winner-argon2).
  *
- * @group Core
- * @singleton Yes
+ * @group Hash
  *
  * @class Argon
- * @static
  */
 class Argon {
   /**

--- a/src/Hash/Drivers/Argon.js
+++ b/src/Hash/Drivers/Argon.js
@@ -9,30 +9,20 @@
  * file that was distributed with this source code.
 */
 
+const argon2 = require('argon2')
+
 /**
- * Hash plain values using the provided hash algorithm.
- * It is considered to be used when saving user passwords to the database.
+ * Hash plain values using [argon2](https://github.com/P-H-C/phc-winner-argon2).
  *
  * @group Core
  * @singleton Yes
  *
- * @class Hash
- * @constructor
+ * @class Argon
+ * @static
  */
-class Hash {
-  constructor (driver) {
-    /**
-     * The driver in use for logging
-     *
-     * @type {Object}
-     *
-     * @attribute driver
-     */
-    this.driver = driver
-  }
-
+class Argon {
   /**
-   * Hash plain value using the given driver.
+   * Hash plain value using argon2.
    *
    * @method make
    * @async
@@ -41,14 +31,9 @@ class Hash {
    * @param  {Object} config
    *
    * @return {String}
-   *
-   * @example
-   * ```js
-   * const hashed = await Hash.make('my-secret-password')
-   * ```
    */
-  make (value, config) {
-    return this.driver.make(value, config)
+  make (value, config = {}) {
+    return argon2.hash(value, config)
   }
 
   /**
@@ -65,17 +50,18 @@ class Hash {
    * @param  {String} hash
    *
    * @return {Boolean}
-   *
-   * @example
-   * ```
-   * const verified = await Hash.verify('password', 'existing-hash')
-   * if (verified) {
-   * }
-   * ```
    */
-  verify (value, hash) {
-    return this.driver.verify(value, hash)
+  async verify (value, hash) {
+    if (value === undefined) {
+      return false
+    }
+
+    if (await argon2.verify(hash, value)) {
+      return true
+    }
+
+    return false
   }
 }
 
-module.exports = Hash
+module.exports = Argon

--- a/src/Hash/Drivers/Bcrypt.js
+++ b/src/Hash/Drivers/Bcrypt.js
@@ -32,8 +32,8 @@ class Bcrypt {
    *
    * @return {String}
    */
-  make (value, config = {}) {
-    const round = config.round || 10
+  make (value, config) {
+    const round = config.round || config || 10
 
     return new Promise(function (resolve, reject) {
       bcrypt.hash(value, round, function (error, hash) {

--- a/src/Hash/Drivers/Bcrypt.js
+++ b/src/Hash/Drivers/Bcrypt.js
@@ -31,7 +31,13 @@ class Bcrypt {
    * @return {String}
    */
   make (value, config) {
-    const round = config.round || config || 10
+    let round
+
+    if (config === undefined) {
+      round = 10
+    } else {
+      round = config.round || config
+    }
 
     return new Promise(function (resolve, reject) {
       bcrypt.hash(value, round, function (error, hash) {

--- a/src/Hash/Drivers/Bcrypt.js
+++ b/src/Hash/Drivers/Bcrypt.js
@@ -14,11 +14,9 @@ const bcrypt = require('bcryptjs')
 /**
  * Hash plain values using [bcryptjs](https://www.npmjs.com/package/bcryptjs).
  *
- * @group Core
- * @singleton Yes
+ * @group Hash
  *
  * @class Bcrypt
- * @static
  */
 class Bcrypt {
   /**

--- a/src/Hash/Drivers/Bcrypt.js
+++ b/src/Hash/Drivers/Bcrypt.js
@@ -45,7 +45,7 @@ class Bcrypt {
     })
   }
 
-    /**
+  /**
    * Verify an existing hash with the plain value. Though this
    * method returns a promise, it never rejects the promise
    * and this is just for the sake of simplicity, since

--- a/src/Hash/Drivers/Bcrypt.js
+++ b/src/Hash/Drivers/Bcrypt.js
@@ -9,30 +9,20 @@
  * file that was distributed with this source code.
 */
 
+const bcrypt = require('bcryptjs')
+
 /**
- * Hash plain values using the provided hash algorithm.
- * It is considered to be used when saving user passwords to the database.
+ * Hash plain values using [bcryptjs](https://www.npmjs.com/package/bcryptjs).
  *
  * @group Core
  * @singleton Yes
  *
- * @class Hash
- * @constructor
+ * @class Bcrypt
+ * @static
  */
-class Hash {
-  constructor (driver) {
-    /**
-     * The driver in use for logging
-     *
-     * @type {Object}
-     *
-     * @attribute driver
-     */
-    this.driver = driver
-  }
-
+class Bcrypt {
   /**
-   * Hash plain value using the given driver.
+   * Hash plain value using bcrypt.
    *
    * @method make
    * @async
@@ -41,17 +31,21 @@ class Hash {
    * @param  {Object} config
    *
    * @return {String}
-   *
-   * @example
-   * ```js
-   * const hashed = await Hash.make('my-secret-password')
-   * ```
    */
-  make (value, config) {
-    return this.driver.make(value, config)
+  make (value, config = {}) {
+    const round = config.round || 10
+
+    return new Promise(function (resolve, reject) {
+      bcrypt.hash(value, round, function (error, hash) {
+        if (error) {
+          return reject(error)
+        }
+        resolve(hash)
+      })
+    })
   }
 
-  /**
+    /**
    * Verify an existing hash with the plain value. Though this
    * method returns a promise, it never rejects the promise
    * and this is just for the sake of simplicity, since
@@ -65,17 +59,17 @@ class Hash {
    * @param  {String} hash
    *
    * @return {Boolean}
-   *
-   * @example
-   * ```
-   * const verified = await Hash.verify('password', 'existing-hash')
-   * if (verified) {
-   * }
-   * ```
    */
   verify (value, hash) {
-    return this.driver.verify(value, hash)
+    return new Promise(function (resolve, reject) {
+      bcrypt.compare(value, hash, function (error, response) {
+        if (error) {
+          return resolve(false)
+        }
+        resolve(response)
+      })
+    })
   }
 }
 
-module.exports = Hash
+module.exports = Bcrypt

--- a/src/Hash/Drivers/index.js
+++ b/src/Hash/Drivers/index.js
@@ -1,0 +1,15 @@
+'use strict'
+
+/*
+ * adonis-framework
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+module.exports = {
+  bcrypt: require('./Bcrypt'),
+  argon: require('./Argon')
+}

--- a/src/Hash/Facade.js
+++ b/src/Hash/Facade.js
@@ -1,0 +1,112 @@
+'use strict'
+
+/*
+ * adonis-framework
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+const GE = require('@adonisjs/generic-exceptions')
+const HashManager = require('./Manager')
+const Hash = require('./index')
+
+/**
+ * Proxy handler to proxy hash instance
+ * methods
+ *
+ * @type {Object}
+ */
+const proxyHandler = {
+  get (target, name) {
+    /**
+     * if node is inspecting then stick to target properties
+     */
+    if (typeof (name) === 'symbol' || name === 'inspect') {
+      return target[name]
+    }
+
+    /**
+     * if value exists on target, return that
+     */
+    if (typeof (target[name]) !== 'undefined') {
+      return target[name]
+    }
+
+    /**
+     * Fallback to default hasher instance
+     */
+    const hasherInstance = target.driver()
+    if (typeof (hasherInstance[name]) === 'function') {
+      return hasherInstance[name].bind(hasherInstance)
+    }
+
+    return hasherInstance[name]
+  }
+}
+
+/**
+ * HashFacade is exposed by IoC container and it proxy
+ * methods over @ref('Hash') class.
+ *
+ * @group Core
+ * @binding Adonis/Src/Hash
+ * @alias Hash
+ *
+ * @class HashFacade
+ * @constructor
+ */
+class HashFacade {
+  constructor (Config) {
+    this.Config = Config
+    this._hasherInstances = {}
+    return new Proxy(this, proxyHandler)
+  }
+
+  /**
+   * Returns the @ref('Hash') class instance for a given
+   * driver.
+   *
+   * @method driver
+   *
+   * @param  {String}  name
+   *
+   * @return {Hash}
+   */
+  driver (name) {
+    name = name || this.Config.get('hash.driver')
+
+    /**
+     * Throw exception when hash.driver is not defined
+     */
+    if (!name) {
+      throw GE.RuntimeException.missingConfig('driver', 'config/hash.js')
+    }
+
+    /**
+     * Return existing instance if exists
+     */
+    if (this._hasherInstances[name]) {
+      return this._hasherInstances[name]
+    }
+
+    const hasherConfig = this.Config.get(`hash.${name}`)
+
+    /**
+     * Throw exception if there is no config defined for the
+     * given hasher name
+     */
+    if (!hasherConfig) {
+      throw GE.RuntimeException.missingConfig(`hash.${name}`, 'config/hash.js')
+    }
+
+    const driverInstance = HashManager.driver(name, hasherConfig)
+    this._hasherInstances[name] = new Hash(driverInstance)
+
+    return this._hasherInstances[name]
+  }
+}
+
+module.exports = HashFacade

--- a/src/Hash/Facade.js
+++ b/src/Hash/Facade.js
@@ -76,13 +76,13 @@ class HashFacade {
    * @return {Hash}
    */
   driver (name) {
-    name = name || this.Config.get('hash.driver') || 'bcrypt'
+    name = name || this.Config.get('hashing.driver') || 'bcrypt'
 
     /**
      * Throw exception when hash.driver is not defined
      */
     if (!name) {
-      throw GE.RuntimeException.missingConfig('driver', 'config/hash.js')
+      throw GE.RuntimeException.missingConfig('driver', 'config/hashing.js')
     }
 
     /**

--- a/src/Hash/Facade.js
+++ b/src/Hash/Facade.js
@@ -76,7 +76,7 @@ class HashFacade {
    * @return {Hash}
    */
   driver (name) {
-    name = name || this.Config.get('hash.driver')
+    name = name || this.Config.get('hash.driver') || 'bcrypt'
 
     /**
      * Throw exception when hash.driver is not defined
@@ -92,15 +92,7 @@ class HashFacade {
       return this._hasherInstances[name]
     }
 
-    const hasherConfig = this.Config.get(`hash.${name}`)
-
-    /**
-     * Throw exception if there is no config defined for the
-     * given hasher name
-     */
-    if (!hasherConfig) {
-      throw GE.RuntimeException.missingConfig(`hash.${name}`, 'config/hash.js')
-    }
+    const hasherConfig = this.Config.get(`hash.${name}`) || {}
 
     const driverInstance = HashManager.driver(name, hasherConfig)
     this._hasherInstances[name] = new Hash(driverInstance)

--- a/src/Hash/Facade.js
+++ b/src/Hash/Facade.js
@@ -51,7 +51,7 @@ const proxyHandler = {
  * HashFacade is exposed by IoC container and it proxy
  * methods over @ref('Hash') class.
  *
- * @group Core
+ * @group Hash
  * @binding Adonis/Src/Hash
  * @alias Hash
  *

--- a/src/Hash/Manager.js
+++ b/src/Hash/Manager.js
@@ -1,0 +1,75 @@
+'use strict'
+
+/**
+ * adonis-framework
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+const { ioc } = require('@adonisjs/fold')
+const GE = require('@adonisjs/generic-exceptions')
+const Drivers = require('./Drivers')
+
+/**
+ * Hash plain values using the provided hash algorithm.
+ * It is considered to be used when saving user passwords to the database.
+ *
+ * @manager
+ * @group Core
+ * @alias Hash
+ * @binding Adonis/Src/Hash
+ * @singleton Yes
+ *
+ * @class HashManager
+ * @constructor
+ */
+class HashManager {
+  constructor () {
+    this._drivers = {}
+  }
+
+  /**
+   * Extend hasher by adding your own drivers
+   *
+   * @method extend
+   *
+   * @param  {String} name
+   * @param  {Object} implementation
+   *
+   * @return {void}
+   */
+  extend (name, implementation) {
+    this._drivers[name] = implementation
+  }
+
+  /**
+   * Returns the driver instance for a given driver.
+   *
+   * @method driver
+   *
+   * @param  {String} name
+   * @param  {Object} config
+   *
+   * @return {Object}
+   */
+  driver (name, config) {
+    name = name.toLowerCase()
+    const Driver = Drivers[name] || this._drivers[name]
+
+    /**
+     * If driver doesn't exists, let the end user know
+     * about it
+     */
+    if (!Driver) {
+      throw GE.RuntimeException.invoke(`Hash driver ${name} does not exists.`, 500, 'E_INVALID_HASHER_DRIVER')
+    }
+
+    const driverInstance = ioc.make(Driver)
+    return driverInstance
+  }
+}
+
+module.exports = new HashManager()

--- a/src/Hash/Manager.js
+++ b/src/Hash/Manager.js
@@ -18,13 +18,11 @@ const Drivers = require('./Drivers')
  * It is considered to be used when saving user passwords to the database.
  *
  * @manager
- * @group Core
- * @alias Hash
- * @binding Adonis/Src/Hash
+ * @group Hash
  * @singleton Yes
  *
  * @class HashManager
- * @constructor
+ * @static
  */
 class HashManager {
   constructor () {

--- a/src/Hash/index.js
+++ b/src/Hash/index.js
@@ -13,7 +13,7 @@
  * Hash plain values using the provided hash algorithm.
  * It is considered to be used when saving user passwords to the database.
  *
- * @group Core
+ * @group Hash
  * @singleton Yes
  *
  * @class Hash

--- a/test/unit/hash.spec.js
+++ b/test/unit/hash.spec.js
@@ -222,13 +222,13 @@ test.group('Hash | Facade', (group) => {
     assert.isDefined(hashed)
   })
 
-  test('throw exception when no driver is defined', async (assert) => {
+  test('use bcrypt when no driver is defined', async (assert) => {
     const config = new Config()
     config.set('hash', {
     })
 
     const hasher = new HashFacade(config)
-    const fn = () => hasher.make('foo')
-    assert.throw(await fn, 'E_MISSING_CONFIG: driver is not defined inside config/hash.js file')
+    const hashed = await hasher.make('foo')
+    assert.isDefined(hashed)
   })
 })

--- a/test/unit/hash.spec.js
+++ b/test/unit/hash.spec.js
@@ -10,33 +10,81 @@
 */
 
 const test = require('japa')
+const { ioc } = require('@adonisjs/fold')
+const { Config } = require('@adonisjs/sink')
+
+const BcryptDriver = require('../../src/Hash/Drivers').bcrypt
+const ArgonDriver = require('../../src/Hash/Drivers').argon
 const Hash = require('../../src/Hash')
+const HashManager = require('../../src/Hash/Manager')
+const HashFacade = require('../../src/Hash/Facade')
 const HashMock = require('../../src/Hash/Mock')
 
-test.group('Hash', () => {
+test.group('Hash | Bcrypt Driver', (group) => {
   test('hash value', async (assert) => {
+    const Hash = new BcryptDriver()
     const hashed = await Hash.make('foo')
     assert.isDefined(hashed)
   })
 
   test('return true when hash matches', async (assert) => {
+    const Hash = new BcryptDriver()
+
     const hashed = await Hash.make('foo')
     const verified = await Hash.verify('foo', hashed)
     assert.isTrue(verified)
   })
 
   test('return false when hash does not match', async (assert) => {
+    const Hash = new BcryptDriver()
+
     const hashed = await Hash.make('foo')
     const verified = await Hash.verify('bar', hashed)
     assert.isFalse(verified)
   })
 
   test('return false instead of throwing exception', async (assert) => {
+    const Hash = new BcryptDriver()
+
     const hashed = await Hash.make('foo')
     const verified = await Hash.verify(undefined, hashed)
     assert.isFalse(verified)
   })
+})
 
+test.group('Hash | Argon Driver', (group) => {
+  test('hash value', async (assert) => {
+    const Hash = new ArgonDriver()
+    const hashed = await Hash.make('foo')
+    assert.isDefined(hashed)
+  })
+
+  test('return true when hash matches', async (assert) => {
+    const Hash = new ArgonDriver()
+
+    const hashed = await Hash.make('foo')
+    const verified = await Hash.verify('foo', hashed)
+    assert.isTrue(verified)
+  })
+
+  test('return false when hash does not match', async (assert) => {
+    const Hash = new ArgonDriver()
+
+    const hashed = await Hash.make('foo')
+    const verified = await Hash.verify('bar', hashed)
+    assert.isFalse(verified)
+  })
+
+  test('return false instead of throwing exception', async (assert) => {
+    const Hash = new ArgonDriver()
+
+    const hashed = await Hash.make('foo')
+    const verified = await Hash.verify(undefined, hashed)
+    assert.isFalse(verified)
+  })
+})
+
+test.group('Hash | Fake', () => {
   test('return string as it is from mock', async (assert) => {
     const hashed = await HashMock.make('foo')
     assert.equal(hashed, 'foo')
@@ -50,5 +98,137 @@ test.group('Hash', () => {
   test('return true when strings are equal', async (assert) => {
     const verified = await HashMock.verify('foo', 'foo')
     assert.isTrue(verified)
+  })
+})
+
+test.group('Hash | Instance', () => {
+  test('hash password using defined driver', async (assert) => {
+    const Bcrypt = new BcryptDriver()
+    const hash = new Hash(Bcrypt)
+
+    const hashed = await hash.make('foo')
+
+    assert.isDefined(hashed)
+  })
+
+  test('verify hash using defined driver', async (assert) => {
+    const Bcrypt = new BcryptDriver()
+    const hash = new Hash(Bcrypt)
+
+    const hashed = await hash.make('foo')
+    const verified = await hash.verify('foo', hashed)
+
+    assert.isTrue(verified)
+  })
+})
+
+test.group('Hash | Manager', (group) => {
+  group.before(() => {
+    ioc.fake('Adonis/Src/Config', () => new Config())
+  })
+
+  test('extend hasher by adding drivers', (assert) => {
+    const myDriver = {}
+    HashManager.extend('myDriver', myDriver)
+    assert.deepEqual(HashManager._drivers, { myDriver })
+  })
+
+  test('throw error when trying to access invalid driver', (assert) => {
+    const fn = () => HashManager.driver('foo')
+    assert.throw(fn, 'E_INVALID_HASHER_DRIVER: Hash driver foo does not exists')
+  })
+
+  test('return driver instance for a given driver', (assert) => {
+    const bcryptDriver = HashManager.driver('bcrypt')
+    assert.instanceOf(bcryptDriver, BcryptDriver)
+  })
+})
+
+test.group('Hash | Facade', (group) => {
+  group.before(() => {
+    ioc.fake('Adonis/Src/Config', () => new Config())
+  })
+
+  test('return hasher instance with selected driver', (assert) => {
+    const config = new Config()
+    config.set('hash', {
+      driver: 'bcrypt',
+      bcrypt: {}
+    })
+
+    const hasher = new HashFacade(config)
+    assert.instanceOf(hasher.driver('bcrypt'), Hash)
+    assert.instanceOf(hasher.driver('bcrypt').driver, BcryptDriver)
+  })
+
+  test('return hasher instance with extended driver', (assert) => {
+    const myDriver = {
+      make () {}
+    }
+    HashManager.extend('mydriver', myDriver)
+
+    const config = new Config()
+    config.set('hash', {
+      driver: 'mydriver',
+      mydriver: {}
+    })
+
+    const hasher = new HashFacade(config)
+    assert.instanceOf(hasher.driver('mydriver'), Hash)
+    assert.deepEqual(hasher.driver('mydriver').driver, myDriver)
+  })
+
+  test('create singleton hasher instances', (assert) => {
+    const config = new Config()
+    config.set('hash', {
+      driver: 'bcrypt',
+      bcrypt: {},
+      anotherFile: {}
+    })
+
+    const hasher = new HashFacade(config)
+    hasher.driver('bcrypt')
+    assert.lengthOf(Object.keys(hasher._hasherInstances), 1)
+    hasher.driver('bcrypt')
+    assert.lengthOf(Object.keys(hasher._hasherInstances), 1)
+  })
+
+  test('create different instance when hasher is different', (assert) => {
+    const config = new Config()
+    config.set('hash', {
+      driver: 'bcrypt',
+      bcrypt: {},
+      argon: {}
+    })
+
+    const hasher = new HashFacade(config)
+    hasher.driver('bcrypt')
+    assert.lengthOf(Object.keys(hasher._hasherInstances), 1)
+    hasher.driver('argon')
+    assert.lengthOf(Object.keys(hasher._hasherInstances), 2)
+  })
+
+  test('proxy hasher instance methods', async (assert) => {
+    const config = new Config()
+    config.set('hash', {
+      driver: 'bcrypt',
+      bcrypt: {
+        round: 10
+      }
+    })
+
+    const hasher = new HashFacade(config)
+    const hashed = await hasher.make('foo')
+    assert.isDefined(hashed)
+  })
+
+  test('throw exception when no driver is defined', async (assert) => {
+    const config = new Config()
+    config.set('hash', {
+    })
+
+    const hasher = new HashFacade(config)
+    const fn = () => hasher.make('foo')
+    assert.throw(await fn, 'E_MISSING_CONFIG: driver is not defined inside config/hash.js file')
   })
 })


### PR DESCRIPTION
Hey 👋 

This PR completely change how Hash works in Adonis without creating any breaking change.

The new driver system will use `bcrypt` by default if there isn't any configuration (so current codebase will not break).

The new code will let you configure the driver (`bcrypt` or `argon`) via the file `config/hashing.js`. See the example bellow.

```js
// config/hashing.js
module.exports = {
  driver: 'bcrypt',

  bcrypt: {
    round: 10
  }

  argon: {
    timeCost: 4,
    memoryCost: 13,
    parallelism: 2
  }
}
```

If this modification is accepted, I'll provide another PR to add this configuration file to `fullstack`, `api` and `slim` blueprint. I'll also update the current doc to reflect the change.