### PR TITLE
Change error message for the errors caused by the "route.url" view global

### DIFF
--- a/src/View/globals.js
+++ b/src/View/globals.js
@@ -16,11 +16,13 @@ module.exports = function (View, Route, Config) {
    * Return url for the route
    */
   View.global('route', function (...args) {
+    let url
+
     try {
-      const url = Route.url(...args)
+      url = Route.url(...args)
     } catch (error) {
       if (error.message) {
-        throw GE.InvalidArgumentException.invalidParamter(`"route" view global expects ${error.message}`, callback)
+        throw GE.InvalidArgumentException(`"route" view global error: ${error.message}`, callback)
       }
 
       throw error

--- a/src/View/globals.js
+++ b/src/View/globals.js
@@ -21,7 +21,7 @@ module.exports = function (View, Route, Config) {
     try {
       url = Route.url(...args)
     } catch (error) {
-      throw GE.InvalidArgumentException(`"route" view global error: ${error.message}`)
+      throw new GE.InvalidArgumentException(`"route" view global error: ${error.message}`)
     }
 
     const baseUrl = Config ? Config.get('app.http.baseUrl', '') : ''

--- a/src/View/globals.js
+++ b/src/View/globals.js
@@ -21,11 +21,7 @@ module.exports = function (View, Route, Config) {
     try {
       url = Route.url(...args)
     } catch (error) {
-      if (error.message) {
-        throw GE.InvalidArgumentException(`"route" view global error: ${error.message}`)
-      }
-
-      throw error
+      throw GE.InvalidArgumentException(`"route" view global error: ${error.message}`)
     }
 
     const baseUrl = Config ? Config.get('app.http.baseUrl', '') : ''

--- a/src/View/globals.js
+++ b/src/View/globals.js
@@ -22,7 +22,7 @@ module.exports = function (View, Route, Config) {
       url = Route.url(...args)
     } catch (error) {
       if (error.message) {
-        throw GE.InvalidArgumentException(`"route" view global error: ${error.message}`, callback)
+        throw GE.InvalidArgumentException(`"route" view global error: ${error.message}`)
       }
 
       throw error

--- a/src/View/globals.js
+++ b/src/View/globals.js
@@ -9,12 +9,23 @@
  * file that was distributed with this source code.
 */
 
+const GE = require('@adonisjs/generic-exceptions')
+
 module.exports = function (View, Route, Config) {
   /**
    * Return url for the route
    */
   View.global('route', function (...args) {
-    const url = Route.url(...args)
+    try {
+      const url = Route.url(...args)
+    } catch (error) {
+      if (error.message) {
+        throw GE.InvalidArgumentException.invalidParamter(`"route" view global expects ${error.message}`, callback)
+      }
+
+      throw error
+    }
+
     const baseUrl = Config ? Config.get('app.http.baseUrl', '') : ''
     return url && /^http(s)?/.test(url) ? url : `${baseUrl}${url}`
   })

--- a/test/unit/views.spec.js
+++ b/test/unit/views.spec.js
@@ -92,6 +92,20 @@ test.group('Views globals', (group) => {
     assert.equal(view.renderString(template).trim(), '/users/1')
   })
 
+  test('throw exception when a route param is not passed', (assert) => {
+    assert.plan(1)
+
+    const view = new View(this.helpers)
+    globals(view, RouteManager)
+    RouteManager.route('users/:id', function () {}).as('profile')
+
+    try {
+      view.renderString(`{{ route('profile') }}`)
+    } catch ({ message }) {
+      assert.isTrue(message.startsWith('"route" view global error:'))
+    }
+  })
+
   test('make url for a route with base url', (assert) => {
     const view = new View(this.helpers)
     const config = new Config()


### PR DESCRIPTION
## Proposed changes

Quite often I use the `route` view global, and I forget to pass the ID or any other param to the second argument of the global.
For example:

```blade
<a href="{{ route('posts.show') }}">...</a>
```

But as the ID is missing, I get this unclear error message:

> `Expected "id" to be a string`

So I've created an error handler when calling `Route.url()` from the view provider to create a slightly more specific error message.

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-framework/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)