### PR TITLE
Fix Env.load() docblock

### DIFF
--- a/src/Env/index.js
+++ b/src/Env/index.js
@@ -89,7 +89,7 @@ class Env {
    * @param  {Boolean} [overwrite = 'true']
    * @param  {String}  [encoding = 'utf8']
    *
-   * @return {void}
+   * @return {Object}
    */
   load (filePath, overwrite = true, encoding = 'utf8') {
     const options = {


### PR DESCRIPTION
## Proposed changes

The `Env.load()` is not void method. This PR just update the docblock.

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-framework/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
