### PR TITLE
Allow pass query string into route helper.

### DIFF
--- a/src/Route/Manager.js
+++ b/src/Route/Manager.js
@@ -11,6 +11,8 @@
 
 const _ = require('lodash')
 const pathToRegexp = require('path-to-regexp')
+const querystring = require('querystring')
+const url = require('url')
 const Route = require('./index')
 const RouteGroup = require('./Group')
 const RouteStore = require('./Store')
@@ -389,12 +391,22 @@ class RouteManager {
    */
   url (routeNameOrHandler, data, options) {
     options = options || {}
+    data = data || {}
     const route = RouteStore.find(routeNameOrHandler, options.domain)
     if (!route) {
       return null
     }
 
-    const compiledRoute = pathToRegexp.compile(route._route)(data || {})
+    /**
+     * When query string exists.
+     */
+    const queryParams = data.qs || data.query || {}
+
+    let compiledRoute = pathToRegexp.compile(route._route)(data)
+
+    let parsedRoute = url.parse(compiledRoute, true)
+    parsedRoute.search = querystring.stringify(Object.assign(parsedRoute.query, queryParams))
+    compiledRoute = parsedRoute.format()
 
     /**
      * When domain exists, build a complete url over creating

--- a/src/Route/Manager.js
+++ b/src/Route/Manager.js
@@ -400,7 +400,7 @@ class RouteManager {
     /**
      * When query string exists.
      */
-    const queryParams = data.qs || data.query || {}
+    const queryParams = options.qs || options.query || {}
 
     let compiledRoute = pathToRegexp.compile(route._route)(data)
 

--- a/test/unit/route.spec.js
+++ b/test/unit/route.spec.js
@@ -797,6 +797,12 @@ test.group('Route | Manager', (group) => {
     assert.equal(url, 'http://blog.example.com/author/1')
   })
 
+  test('make url with query string', (assert) => {
+    RouteManager.get('users/:id', 'UsersController.show')
+    const url = RouteManager.url('UsersController.show', { id: 1, query: { foo: 'bar' } })
+    assert.equal(url, '/users/1?foo=bar')
+  })
+
   test('define protocol for the url', (assert) => {
     RouteManager.get('users/:id', 'UsersController.show')
     RouteManager.get('author/:id', 'UsersController.show').domain('blog.example.com')

--- a/test/unit/route.spec.js
+++ b/test/unit/route.spec.js
@@ -797,6 +797,12 @@ test.group('Route | Manager', (group) => {
     assert.equal(url, 'http://blog.example.com/author/1')
   })
 
+  test('make url with query string (without params)', (assert) => {
+    RouteManager.get('users', 'UsersController.show')
+    const url = RouteManager.url('UsersController.show', null, { query: { foo: 'bar' } })
+    assert.equal(url, '/users?foo=bar')
+  })
+
   test('make url with query string', (assert) => {
     RouteManager.get('users/:id', 'UsersController.show')
     const url = RouteManager.url('UsersController.show', { id: 1 }, { query: { foo: 'bar' } })

--- a/test/unit/route.spec.js
+++ b/test/unit/route.spec.js
@@ -799,8 +799,25 @@ test.group('Route | Manager', (group) => {
 
   test('make url with query string', (assert) => {
     RouteManager.get('users/:id', 'UsersController.show')
-    const url = RouteManager.url('UsersController.show', { id: 1, query: { foo: 'bar' } })
+    const url = RouteManager.url('UsersController.show', { id: 1 }, { query: { foo: 'bar' } })
     assert.equal(url, '/users/1?foo=bar')
+  })
+
+  test('make url with query string (qs)', (assert) => {
+    RouteManager.get('users/:id', 'UsersController.show')
+    const url = RouteManager.url('UsersController.show', { id: 1 }, { qs: { foo: 'bar' } })
+    assert.equal(url, '/users/1?foo=bar')
+  })
+
+  test('make url for route with options', (assert) => {
+    RouteManager.get('users/:id', 'UsersController.show')
+    RouteManager.get('author/:id', 'UsersController.show').domain('blog.example.com')
+    const url = RouteManager.url('UsersController.show', { id: 1 }, {
+      domain: 'blog.example.com',
+      protocol: 'https',
+      query: { foo: 'bar' }
+    })
+    assert.equal(url, 'https://blog.example.com/author/1?foo=bar')
   })
 
   test('define protocol for the url', (assert) => {


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Pass query object into route helper second argument to make query string.

Follow issue: [#716](https://github.com/adonisjs/adonis-framework/issues/716)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-framework/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

### Sample Code
```javascript
route('posts.show', { id: 1, query: { foo: 'bar' } })
// => /post/1?foo=bar
```

```html
<a href="{{ route('posts.show', { id: 1, query: { foo: 'bar' } }) }}">Show post</a>
<!-- href="/post/1?foo=bar" -->
```