### PR TITLE
feat: duplicate route name failing test

### DIFF
--- a/test/unit/route.spec.js
+++ b/test/unit/route.spec.js
@@ -719,7 +719,7 @@ test.group('Route | Manager', (group) => {
     assert.throw(fn, 'E_NESTED_ROUTE_GROUPS: Nested route groups are not allowed')
   })
 
-  test('throw exception when name is already used', (assert) => {
+  test.failing('throw exception when name is already used', (assert) => {
     const fn = () => {
       RouteManager.get('/', function () {}).as('foo')
       RouteManager.get('/', function () {}).as('foo')

--- a/test/unit/route.spec.js
+++ b/test/unit/route.spec.js
@@ -719,6 +719,14 @@ test.group('Route | Manager', (group) => {
     assert.throw(fn, 'E_NESTED_ROUTE_GROUPS: Nested route groups are not allowed')
   })
 
+  test('throw exception when name is already used', (assert) => {
+    const fn = () => {
+      RouteManager.get('/', function () {}).as('foo')
+      RouteManager.get('/', function () {}).as('foo')
+    }
+    assert.throw(fn, 'E_ROUTE_NAME_TAKEN: This route name is already used')
+  })
+
   test('define route resource', (assert) => {
     const resource = RouteManager.resource('users', 'UsersController')
     assert.instanceOf(resource, RouteResource)


### PR DESCRIPTION
## Proposed changes

This PR is the starting point to prevent duplicated route name. I don't have a fix for this failing test at the moment since you register the route before assigning it a name. I need your opinion if this is an issue, and when you want to throw an exception ?
```
Route.get('/users', () => '').as('users.index')
Route.get('/users', () => '').as('users.index')
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-framework/blob/develop/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

