### PR TITLE
fixed the license badge in README.md pointing to an invalid URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@
 [typescript-image]: https://img.shields.io/badge/Typescript-294E80.svg?style=for-the-badge&logo=typescript
 
 [license-url]: LICENSE.md
-[license-image]: https://img.shields.io/aur/license/pac.svg?style=for-the-badge
+[license-image]: https://img.shields.io/github/license/adonisjs/adonis-framework?style=for-the-badge


### PR DESCRIPTION
#1160

## Proposed changes

Purely an update to the shields.io license image to show "MIT License" as it currently shows "Package not found".

## Types of changes

An updated shields.io URL for the license-image in README.md which tracks the repository license and shows the relevant image.

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-framework/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments
Just a note to the maintainers regarding shields.io rate limits:

> If your GitHub badge errors, it might be because you hit GitHub's rate limits. You can increase Shields.io's rate limit by adding the Shields GitHub application using your GitHub account.

It's a trivial change, I found Adonis after looking for Laravel like frameworks for node. the "Package not found" made me think something is broken/outdated, then I realized that it's just the license image. Just wanted to help out, Can't wait to dive into Adonis!