### PR TITLE
feat(encryption): move to driver based system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,13 @@ coverage
 .nyc_output
 .idea
 .vscode/
+.yalc
 *.sublime-project
 *.sublime-workspace
 *.log
 build
 dist
+yalc.lock
 yarn.lock
 shrinkwrap.yaml
 package-lock.json

--- a/modules/encryption/define_config.ts
+++ b/modules/encryption/define_config.ts
@@ -1,0 +1,67 @@
+/*
+ * @adonisjs/core
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { InvalidArgumentsException } from '@poppinss/utils'
+import driversCollection from './drivers_collection.js'
+import type { EncryptionDriversList } from '../../src/types.js'
+import type { ManagerDriverFactory } from '../../types/encryption.js'
+
+export function defineConfig<
+  KnownEncrypters extends Record<
+    string,
+    {
+      [K in keyof EncryptionDriversList]: { driver: K } & Parameters<EncryptionDriversList[K]>[0]
+    }[keyof EncryptionDriversList]
+  >,
+>(config: {
+  default?: keyof KnownEncrypters
+  list: KnownEncrypters
+}): {
+  default?: keyof KnownEncrypters
+  driversInUse: Set<keyof EncryptionDriversList>
+  list: { [K in keyof KnownEncrypters]: ManagerDriverFactory }
+} {
+  /**
+   * Encrypters list should always be provided
+   */
+  if (!config.list) {
+    throw new InvalidArgumentsException('Missing "list" property in encryption config')
+  }
+
+  /**
+   * The default encrypter should be mentioned in the list
+   */
+  if (config.default && !config.list[config.default]) {
+    throw new InvalidArgumentsException(
+      `Missing "list.${String(
+        config.default
+      )}" in encryption config. It is referenced by the "default" property`
+    )
+  }
+
+  /**
+   * Converting list config to a collection that encryption manager can use
+   */
+  const driversInUse: Set<keyof EncryptionDriversList> = new Set()
+  const managerEncrypters = Object.keys(config.list).reduce(
+    (result, encrypter: keyof KnownEncrypters) => {
+      const encrypterConfig = config.list[encrypter]
+      driversInUse.add(encrypterConfig.driver)
+      result[encrypter] = () => driversCollection.create(encrypterConfig.driver, encrypterConfig)
+      return result
+    },
+    {} as { [K in keyof KnownEncrypters]: ManagerDriverFactory }
+  )
+
+  return {
+    default: config.default,
+    driversInUse,
+    list: managerEncrypters,
+  }
+}

--- a/modules/encryption/drivers/legacy.ts
+++ b/modules/encryption/drivers/legacy.ts
@@ -1,0 +1,10 @@
+/*
+ * @adonisjs/core
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+export * from '@adonisjs/encryption/drivers/legacy'

--- a/modules/encryption/drivers_collection.ts
+++ b/modules/encryption/drivers_collection.ts
@@ -1,0 +1,58 @@
+/*
+ * @adonisjs/core
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * This class exists in the core, because it maintains a list of
+ * globally available drivers applicable to the encryption manager
+ * instance registered with the container.
+ */
+
+import { RuntimeException } from '@poppinss/utils'
+import type { EncryptionDriversList } from '../../src/types.js'
+
+/**
+ * A global collection of Hash drivers
+ */
+class EncryptionDriversCollection {
+  /**
+   * List of registered drivers
+   */
+  list: Partial<EncryptionDriversList> = {}
+
+  /**
+   * Extend drivers collection and add a custom
+   * driver to it.
+   */
+  extend<Name extends keyof EncryptionDriversList>(
+    driverName: Name,
+    factoryCallback: EncryptionDriversList[Name]
+  ): this {
+    this.list[driverName] = factoryCallback
+    return this
+  }
+
+  /**
+   * Creates the driver instance with config
+   */
+  create<Name extends keyof EncryptionDriversList>(
+    name: Name,
+    config: Parameters<EncryptionDriversList[Name]>[0]
+  ) {
+    const driverFactory = this.list[name]
+    if (!driverFactory) {
+      throw new RuntimeException(
+        `Unknown encryption driver "${String(name)}". Make sure the driver is registered`
+      )
+    }
+
+    return driverFactory(config as any)
+  }
+}
+
+export default new EncryptionDriversCollection()

--- a/modules/encryption/main.ts
+++ b/modules/encryption/main.ts
@@ -8,3 +8,5 @@
  */
 
 export * from '@adonisjs/encryption'
+export { defineConfig } from './define_config.js'
+export { default as driversList } from './drivers_collection.js'

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@adonisjs/application": "^7.1.2-9",
     "@adonisjs/bodyparser": "^9.3.2-7",
     "@adonisjs/config": "^4.2.1-3",
-    "@adonisjs/encryption": "^5.1.2-2",
+    "@adonisjs/encryption": "file:.yalc/@adonisjs/encryption",
     "@adonisjs/env": "^4.2.0-4",
     "@adonisjs/events": "^8.4.9-4",
     "@adonisjs/fold": "^9.9.3-7",

--- a/providers/app_provider.ts
+++ b/providers/app_provider.ts
@@ -9,7 +9,6 @@
 
 import { Config } from '../modules/config.js'
 import { Logger } from '../modules/logger.js'
-import { Encryption } from '../modules/encryption.js'
 import type { ApplicationService, LoggerService } from '../src/types.js'
 
 /**
@@ -86,17 +85,6 @@ export default class AppServiceProvider {
   }
 
   /**
-   * Register the encryption service to the container
-   */
-  protected registerEncryption() {
-    this.app.container.singleton(Encryption, () => {
-      const appKey = this.app.config.get<string>('app.appKey')
-      return new Encryption({ secret: appKey })
-    })
-    this.app.container.alias('encryption', Encryption)
-  }
-
-  /**
    * Registers bindings
    */
   register() {
@@ -106,7 +94,6 @@ export default class AppServiceProvider {
     this.registerLogger()
     this.registerConfig()
     this.registerEmitter()
-    this.registerEncryption()
     this.registerTestUtils()
   }
 }

--- a/providers/encryption_provider.ts
+++ b/providers/encryption_provider.ts
@@ -1,0 +1,68 @@
+/*
+ * @adonisjs/core
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { Encryption, driversList } from '../modules/encryption/main.js'
+import type { ApplicationService, EncryptionDriversList } from '../src/types.js'
+
+/**
+ * Registers the encryption module with the container
+ */
+export default class EncryptionServiceProvider {
+  constructor(protected app: ApplicationService) {}
+
+  /**
+   * Lazily registers encryption driver with the driversList collection
+   */
+  protected async registerEncryptionDrivers(driversInUse: Set<keyof EncryptionDriversList>) {
+    if (driversInUse.has('legacy')) {
+      const { Legacy } = await import('../modules/encryption/drivers/legacy.js')
+      driversList.extend('legacy', (config) => new Legacy(config))
+    }
+  }
+
+  /**
+   * Registering the encryption class to resolve an instance with the
+   * default encrypters.
+   */
+  protected registerEncryption() {
+    this.app.container.singleton(Encryption, async (resolver) => {
+      const encryptionManager = await resolver.make('encryption')
+      return encryptionManager.use()
+    })
+  }
+
+  /**
+   * Registers the encryption manager with the container
+   */
+  protected registerEncryptionManager() {
+    this.app.container.singleton('encryption', async () => {
+      const config = this.app.config.get<any>('encryption')
+      const { EncryptionManager } = await import('../modules/encryption/main.js')
+      return new EncryptionManager(config)
+    })
+  }
+
+  /**
+   * Registers bindings
+   */
+  register() {
+    this.registerEncryptionManager()
+    this.registerEncryption()
+  }
+
+  /**
+   * Register drivers based upon encryption config
+   */
+  boot() {
+    this.app.container.resolving('encryption', async () => {
+      const config = this.app.config.get<any>('encryption')
+      await this.registerEncryptionDrivers(config.driversInUse)
+    })
+  }
+}

--- a/tests/providers.spec.ts
+++ b/tests/providers.spec.ts
@@ -14,9 +14,9 @@ import { Config } from '../modules/config.js'
 import { Emitter } from '../modules/events.js'
 import { Kernel } from '../modules/ace/kernel.js'
 import { TestUtils } from '../src/test_utils/main.js'
-import { Encryption } from '../modules/encryption.js'
 import { Router, Server } from '../modules/http/main.js'
 import { Hash, HashManager } from '../modules/hash/main.js'
+import { EncryptionManager } from '../modules/encryption/main.js'
 import { Logger, LoggerManager } from '../modules/logger.js'
 import { IgnitorFactory } from '../factories/core/ignitor.js'
 import BodyParserMiddleware from '../modules/bodyparser/bodyparser_middleware.js'
@@ -66,6 +66,7 @@ test.group('Providers', () => {
           providers: [
             './providers/app_provider.js',
             './providers/hash_provider.js',
+            './providers/encryption_provider.js',
             './providers/http_provider.js',
             './providers/repl_provider.js',
           ],
@@ -98,7 +99,7 @@ test.group('Providers', () => {
     assert.strictEqual(app, appService)
     assert.instanceOf(configService, Config)
     assert.instanceOf(emitterService, Emitter)
-    assert.instanceOf(encryptionService, Encryption)
+    assert.instanceOf(encryptionService, EncryptionManager)
     assert.instanceOf(hashService, HashManager)
     assert.instanceOf(loggerService, LoggerManager)
     assert.instanceOf(routerService, Router)

--- a/tests/repl/bindings.spec.ts
+++ b/tests/repl/bindings.spec.ts
@@ -26,6 +26,7 @@ test.group('Repl | bindings', () => {
           providers: [
             '../providers/app_provider.js',
             '../providers/hash_provider.js',
+            '../providers/encryption_provider.js',
             '../providers/http_provider.js',
           ],
         },


### PR DESCRIPTION
Hey! 👋🏻 

This PR moves any reference to the encryption to the new driver-based system.

We still have to update related packages like `@adonisjs/http-server`, and the configuration of any starters.

Related: https://github.com/adonisjs/road-to-v6/issues/18