### PR TITLE
fix(commands) : make the APP_KEY an empty value for the .env.example file

### DIFF
--- a/commands/generate_key.ts
+++ b/commands/generate_key.ts
@@ -43,7 +43,7 @@ export default class GenerateKey extends BaseCommand {
 
     if (writeToFile) {
       const editor = await EnvEditor.create(this.app.appRoot)
-      editor.add('APP_KEY', secureKey)
+      editor.add('APP_KEY', secureKey, true)
       await editor.save()
       this.logger.action('add APP_KEY to .env').succeeded()
     } else {


### PR DESCRIPTION
### 🔗 Linked issue

https://discord.com/channels/423256550564691970/1282329972241076306

### ❓ Type of change

- [x ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I've added the true parameter to the editor.add function so that the key value is not written to the .env.example file, but only an empty value.

### 📝 Checklist

- [ x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
