### PR TITLE
feat: add `--env=production` flag to node ace generate:key

### DIFF
--- a/commands/generate_key.ts
+++ b/commands/generate_key.ts
@@ -24,12 +24,17 @@ export default class GenerateKey extends BaseCommand {
   })
   declare show: boolean
 
+  @flags.string()
+  declare env: string
+
   @flags.boolean({
     description: 'Force update .env file in production environment',
   })
   declare force: boolean
 
   async run() {
+    const withEmptyExampleValue = this.env === 'production'
+
     let writeToFile = process.env.NODE_ENV !== 'production'
     if (this.force) {
       writeToFile = true
@@ -43,7 +48,7 @@ export default class GenerateKey extends BaseCommand {
 
     if (writeToFile) {
       const editor = await EnvEditor.create(this.app.appRoot)
-      editor.add('APP_KEY', secureKey)
+      editor.add('APP_KEY', secureKey, withEmptyExampleValue)
       await editor.save()
       this.logger.action('add APP_KEY to .env').succeeded()
     } else {


### PR DESCRIPTION
### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This pull request introduces a new `--env=production` flag to the `node ace generate:key` command.

**Key Changes**:
- When the commande is run with the `--end=production` flag, the `APP_KEY` in `.env.example` is cleared (set to an empty value).
- Simultaneously, the `APP_KEY` in the `.env` file is updated with a new, randomly generated key, ensuring the correct key for the production environment is set. 

**Why is this change required?**
This enhancement simplifies key management for production environments by automatically clearing the `APP_KEY` in `.env.example`, reducing the risk of accidentally committing sensitive keys. It also ensures that a new key is generated and set directly in `.env` without manual intervention.
