### PR TITLE
doc: update installPackages jsdoc to match current implementation

### DIFF
--- a/modules/ace/codemods.ts
+++ b/modules/ace/codemods.ts
@@ -297,7 +297,7 @@ export class Codemods extends EventEmitter {
    * name like :
    *
    * ```
-   * this.installPackages(['@adonisjs/lucid@next', '@adonisjs/auth@3.0.0'])
+   * this.installPackages([{ name: '@adonisjs/lucid@next', isDevDependency: false }])
    * ```
    */
   async installPackages(packages: { name: string; isDevDependency: boolean }[]) {


### PR DESCRIPTION
### 📚 Description

I've revised the JSDoc comment for the `installPackages` method to reflect its current signature. The previous comment was inconsistent with the method's parameters, which caused confusion while I was working on this package.