### PR TITLE
feat: add support for installing specific versions of packages

### DIFF
--- a/tests/commands/add.spec.ts
+++ b/tests/commands/add.spec.ts
@@ -173,6 +173,32 @@ test.group('Install', (group) => {
     assert.deepEqual(pkgJson.devDependencies, { test: 'file:node_modules/foo' })
   })
 
+  test('should install specific version of dependency', async ({ assert, fs }) => {
+    const ace = await new AceFactory().make(fs.baseUrl, {
+      importer: (filePath) => import(join(filePath, `index.js?${Math.random()}`)),
+    })
+
+    await setupProject(fs, 'npm')
+    await setupPackage(fs)
+
+    const packageVersion = await fs.contentsJson('package.json')
+    console.log({ packageVersion })
+
+    await ace.app.init()
+
+    ace.addLoader(new ListLoader([Configure]))
+    ace.ui.switchMode('raw')
+    ace.prompt.trap('install').accept()
+
+    const command = await ace.create(Add, [new URL('node_modules/foo', fs.baseUrl).href, 'latest'])
+    command.verbose = true
+
+    await command.exec()
+
+    const pkgJson = await fs.contentsJson('package.json')
+    assert.deepEqual(pkgJson.devDependencies, { test: 'file:node_modules/foo' })
+  })
+
   test('pass unknown args to configure', async ({ fs, assert }) => {
     const ace = await new AceFactory().make(fs.baseUrl, {
       importer: (filePath) => import(join(filePath, `index.js?${Math.random()}`)),


### PR DESCRIPTION
### 🔗 Linked issue

This enables what's described in https://github.com/adonisjs/ace/issues/163

However, I cannot think of a way to actually test this, since `@antfu/install-pkg` doesn't provide a way to not actually do anything (i.e., run under test)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Currently when using `node ace add <package>` it's not possible to install a prerelease or specific released version of a package, so if we have `@adonisjs/transmit` releasing a prerelease of `v5.0.0-next.0` which isn't the `latest` tag, but the `next` tag, we can't install that through `node ace add`, instead we'd have to install manually via `package.json` the specific version, and then call `node ace configure <package>` separately.

The way the tests are written, I cannot see a way to actually add test coverage for this.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
