### PR TITLE
feat: enable allowUnknownFlags for specific commands

### DIFF
--- a/commands/make/controller.ts
+++ b/commands/make/controller.ts
@@ -10,6 +10,7 @@
 import string from '@poppinss/utils/string'
 import { stubsRoot } from '../../stubs/main.js'
 import { args, flags, BaseCommand } from '../../modules/ace/main.js'
+import { CommandOptions } from '../../types/ace.js'
 
 /**
  * The make controller command to create an HTTP controller
@@ -17,6 +18,10 @@ import { args, flags, BaseCommand } from '../../modules/ace/main.js'
 export default class MakeController extends BaseCommand {
   static commandName = 'make:controller'
   static description = 'Create a new HTTP controller class'
+
+  static options: CommandOptions = {
+    allowUnknownFlags: true,
+  }
 
   @args.string({ description: 'The name of the controller' })
   declare name: string

--- a/commands/make/event.ts
+++ b/commands/make/event.ts
@@ -9,6 +9,7 @@
 
 import { stubsRoot } from '../../stubs/main.js'
 import { args, BaseCommand } from '../../modules/ace/main.js'
+import { CommandOptions } from '../../types/ace.js'
 
 /**
  * The make event command to create a class based event
@@ -16,6 +17,10 @@ import { args, BaseCommand } from '../../modules/ace/main.js'
 export default class MakeEvent extends BaseCommand {
   static commandName = 'make:event'
   static description = 'Create a new event class'
+
+  static options: CommandOptions = {
+    allowUnknownFlags: true,
+  }
 
   @args.string({ description: 'Name of the event' })
   declare name: string

--- a/commands/make/exception.ts
+++ b/commands/make/exception.ts
@@ -9,6 +9,7 @@
 
 import { stubsRoot } from '../../stubs/main.js'
 import { args, BaseCommand } from '../../modules/ace/main.js'
+import { CommandOptions } from '../../types/ace.js'
 
 /**
  * Make a new exception class
@@ -16,6 +17,10 @@ import { args, BaseCommand } from '../../modules/ace/main.js'
 export default class MakeException extends BaseCommand {
   static commandName = 'make:exception'
   static description = 'Create a new custom exception class'
+
+  static options: CommandOptions = {
+    allowUnknownFlags: true,
+  }
 
   @args.string({ description: 'Name of the exception' })
   declare name: string

--- a/commands/make/listener.ts
+++ b/commands/make/listener.ts
@@ -9,6 +9,7 @@
 
 import { stubsRoot } from '../../stubs/main.js'
 import { args, flags, BaseCommand } from '../../modules/ace/main.js'
+import { CommandOptions } from '../../types/ace.js'
 
 /**
  * The make listener command to create a class based event
@@ -17,6 +18,10 @@ import { args, flags, BaseCommand } from '../../modules/ace/main.js'
 export default class MakeListener extends BaseCommand {
   static commandName = 'make:listener'
   static description = 'Create a new event listener class'
+
+  static options: CommandOptions = {
+    allowUnknownFlags: true,
+  }
 
   @args.string({ description: 'Name of the event listener' })
   declare name: string

--- a/commands/make/middleware.ts
+++ b/commands/make/middleware.ts
@@ -13,6 +13,7 @@ import { basename, extname, relative } from 'node:path'
 
 import { stubsRoot } from '../../stubs/main.js'
 import { args, BaseCommand, flags } from '../../modules/ace/main.js'
+import { CommandOptions } from '../../types/ace.js'
 
 /**
  * The make middleware command to create a new middleware
@@ -21,6 +22,10 @@ import { args, BaseCommand, flags } from '../../modules/ace/main.js'
 export default class MakeMiddleware extends BaseCommand {
   static commandName = 'make:middleware'
   static description = 'Create a new middleware class for HTTP requests'
+
+  static options: CommandOptions = {
+    allowUnknownFlags: true,
+  }
 
   @args.string({ description: 'Name of the middleware' })
   declare name: string

--- a/commands/make/service.ts
+++ b/commands/make/service.ts
@@ -9,6 +9,7 @@
 
 import { stubsRoot } from '../../stubs/main.js'
 import { args, BaseCommand } from '../../modules/ace/main.js'
+import { CommandOptions } from '../../types/ace.js'
 
 /**
  * Make a new service class
@@ -16,6 +17,10 @@ import { args, BaseCommand } from '../../modules/ace/main.js'
 export default class MakeService extends BaseCommand {
   static commandName = 'make:service'
   static description = 'Create a new service class'
+
+  static options: CommandOptions = {
+    allowUnknownFlags: true,
+  }
 
   @args.string({ description: 'Name of the service' })
   declare name: string

--- a/commands/make/validator.ts
+++ b/commands/make/validator.ts
@@ -9,6 +9,7 @@
 
 import { stubsRoot } from '../../stubs/main.js'
 import { args, flags, BaseCommand } from '../../modules/ace/main.js'
+import { CommandOptions } from '../../types/ace.js'
 
 /**
  * Make a new VineJS validator
@@ -16,6 +17,10 @@ import { args, flags, BaseCommand } from '../../modules/ace/main.js'
 export default class MakeValidator extends BaseCommand {
   static commandName = 'make:validator'
   static description = 'Create a new file to define VineJS validators'
+
+  static options: CommandOptions = {
+    allowUnknownFlags: true,
+  }
 
   @args.string({ description: 'Name of the validator file' })
   declare name: string


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

According to the [AdonisJS documentation](https://docs.adonisjs.com/guides/concepts/scaffolding#using-cli-flags-to-customize-stub-output-destination), commands can accept unknown flags, which can be used in stubs to customize behavior such as output destination.

However, by default, the allowUnknownFlags option is disabled, preventing this feature from working as intended.

This PR enables the allowUnknownFlags option for specific commands that benefit from accepting and using additional flags—restoring alignment with the documented behavior. This is useful when using modular architecture.

~~If this PR is approved and merged, similar changes will be proposed for other packages like Lucid, Mail, and so on.~~ (Edit: It appears that other packages have already enabled this option for make commands)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
