### PR TITLE
feat: add tryValidateUsing to HttpRequest

### DIFF
--- a/modules/http/request_validator.ts
+++ b/modules/http/request_validator.ts
@@ -56,7 +56,7 @@ export class RequestValidator {
    */
   static messagesProvider?: (_: HttpContext) => MessagesProviderContact
 
-  private requestData() {
+  #requestData() {
     const requestBody = this.#ctx.request.all()
     return {
       ...requestBody,
@@ -66,7 +66,7 @@ export class RequestValidator {
     }
   }
 
-  private processValidatorOptions<MetaData extends undefined | Record<string, any>>(
+  #processValidatorOptions<MetaData extends undefined | Record<string, any>>(
     options: RequestValidationOptions<MetaData> | undefined
   ): RequestValidationOptions<any> {
     const validatorOptions: RequestValidationOptions<any> = options || {}
@@ -121,12 +121,12 @@ export class RequestValidator {
     /**
      * Process the validation options
      */
-    const validatorOptions = this.processValidatorOptions(options)
+    const validatorOptions = this.#processValidatorOptions(options)
 
     /**
      * Data to validate
      */
-    const data = validatorOptions.data || this.requestData()
+    const data = validatorOptions.data || this.#requestData()
 
     return validator.validate(data, validatorOptions as any)
   }
@@ -143,12 +143,12 @@ export class RequestValidator {
     /**
      * Process the validation options
      */
-    const validatorOptions = this.processValidatorOptions(options)
+    const validatorOptions = this.#processValidatorOptions(options)
 
     /**
      * Data to validate
      */
-    const data = validatorOptions.data || this.requestData()
+    const data = validatorOptions.data || this.#requestData()
 
     return validator.tryValidate(data, validatorOptions as any)
   }

--- a/modules/http/request_validator.ts
+++ b/modules/http/request_validator.ts
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-import type { VineValidator } from '@vinejs/vine'
+import type { ValidationError, VineValidator } from '@vinejs/vine'
 import type {
   Infer,
   SchemaTypes,
@@ -56,6 +56,39 @@ export class RequestValidator {
    */
   static messagesProvider?: (_: HttpContext) => MessagesProviderContact
 
+  private requestData() {
+    const requestBody = this.#ctx.request.all()
+    return {
+      ...requestBody,
+      params: this.#ctx.request.params(),
+      headers: this.#ctx.request.headers(),
+      cookies: this.#ctx.request.cookiesList(),
+    }
+  }
+
+  private processValidatorOptions<MetaData extends undefined | Record<string, any>>(
+    options: RequestValidationOptions<MetaData> | undefined
+  ): RequestValidationOptions<any> {
+    const validatorOptions: RequestValidationOptions<any> = options || {}
+
+    /**
+     * Assign request specific error reporter
+     */
+    if (RequestValidator.errorReporter && !validatorOptions.errorReporter) {
+      const errorReporter = RequestValidator.errorReporter(this.#ctx)
+      validatorOptions.errorReporter = () => errorReporter
+    }
+
+    /**
+     * Assign request specific messages provider
+     */
+    if (RequestValidator.messagesProvider && !validatorOptions.messagesProvider) {
+      validatorOptions.messagesProvider = RequestValidator.messagesProvider(this.#ctx)
+    }
+
+    return validatorOptions
+  }
+
   /**
    * Validate the current HTTP request data using a VineJS validator.
    * This method automatically includes request body, files, URL parameters,
@@ -85,35 +118,38 @@ export class RequestValidator {
       ? [options?: RequestValidationOptions<MetaData> | undefined]
       : [options: RequestValidationOptions<MetaData>]
   ): Promise<Infer<Schema>> {
-    const validatorOptions: RequestValidationOptions<any> = options || {}
-
     /**
-     * Assign request specific error reporter
+     * Process the validation options
      */
-    if (RequestValidator.errorReporter && !validatorOptions.errorReporter) {
-      const errorReporter = RequestValidator.errorReporter(this.#ctx)
-      validatorOptions.errorReporter = () => errorReporter
-    }
-
-    /**
-     * Assign request specific messages provider
-     */
-    if (RequestValidator.messagesProvider && !validatorOptions.messagesProvider) {
-      validatorOptions.messagesProvider = RequestValidator.messagesProvider(this.#ctx)
-    }
-
-    const requestBody = this.#ctx.request.all()
+    const validatorOptions = this.processValidatorOptions(options)
 
     /**
      * Data to validate
      */
-    const data = validatorOptions.data || {
-      ...requestBody,
-      params: this.#ctx.request.params(),
-      headers: this.#ctx.request.headers(),
-      cookies: this.#ctx.request.cookiesList(),
-    }
+    const data = validatorOptions.data || this.requestData()
 
     return validator.validate(data, validatorOptions as any)
+  }
+
+  async tryValidateUsing<
+    Schema extends SchemaTypes,
+    MetaData extends undefined | Record<string, any>,
+  >(
+    validator: VineValidator<Schema, MetaData>,
+    ...[options]: [undefined] extends MetaData
+      ? [options?: RequestValidationOptions<MetaData> | undefined]
+      : [options: RequestValidationOptions<MetaData>]
+  ): Promise<[ValidationError, null] | [null, Infer<Schema>]> {
+    /**
+     * Process the validation options
+     */
+    const validatorOptions = this.processValidatorOptions(options)
+
+    /**
+     * Data to validate
+     */
+    const data = validatorOptions.data || this.requestData()
+
+    return validator.tryValidate(data, validatorOptions as any)
   }
 }

--- a/providers/vinejs_provider.ts
+++ b/providers/vinejs_provider.ts
@@ -80,5 +80,9 @@ export default class VineJSServiceProvider {
     HttpRequest.macro('validateUsing', function (this: HttpRequest, ...args) {
       return new RequestValidator(this.ctx!).validateUsing(...args)
     })
+
+    HttpRequest.macro('tryValidateUsing', function (this: HttpRequest, ...args) {
+      return new RequestValidator(this.ctx!).tryValidateUsing(...args)
+    })
   }
 }

--- a/tests/request_validator.spec.ts
+++ b/tests/request_validator.spec.ts
@@ -9,7 +9,7 @@
 
 import { test } from '@japa/runner'
 import { type FieldContext } from '@vinejs/vine/types'
-import vine, { SimpleErrorReporter, SimpleMessagesProvider } from '@vinejs/vine'
+import vine, { SimpleErrorReporter, SimpleMessagesProvider, ValidationError } from '@vinejs/vine'
 
 import { RequestValidator } from '../modules/http/main.ts'
 import { IgnitorFactory } from '../factories/core/ignitor.ts'
@@ -318,5 +318,163 @@ test.group('Request validator', () => {
         },
       ])
     }
+  })
+
+  test('try validate using')
+    .with([
+      { expectValid: true, body: { username: 'virk' } },
+      { expectValid: false, body: { foo: true } },
+    ])
+    .run(async ({ assert }, { expectValid, body }) => {
+      assert.plan(2)
+
+      const ignitor = new IgnitorFactory()
+        .withCoreConfig()
+        .merge({
+          rcFileContents: {
+            providers: [
+              () => import('../providers/app_provider.js'),
+              () => import('../providers/vinejs_provider.js'),
+            ],
+          },
+        })
+        .create(BASE_URL)
+
+      const testUtils = new TestUtilsFactory().create(ignitor)
+      await testUtils.app.init()
+      await testUtils.app.boot()
+      await testUtils.boot()
+
+      const ctx = await testUtils.createHttpContext()
+      const validator = vine.compile(
+        vine.object({
+          username: vine.string(),
+        })
+      )
+
+      ctx.request.setInitialBody(body)
+
+      const [error, data] = await ctx.request.tryValidateUsing(validator)
+
+      if (expectValid) {
+        assert.isNull(error)
+        assert.deepEqual(data, body)
+      } else {
+        assert.instanceOf(error, ValidationError)
+        assert.isNull(data)
+      }
+    })
+
+  test('try validate using with custom messages provider', async ({ assert, cleanup }) => {
+    assert.plan(3)
+
+    const ignitor = new IgnitorFactory()
+      .withCoreConfig()
+      .merge({
+        rcFileContents: {
+          providers: [
+            () => import('../providers/app_provider.js'),
+            () => import('../providers/vinejs_provider.js'),
+          ],
+        },
+      })
+      .create(BASE_URL)
+
+    const testUtils = new TestUtilsFactory().create(ignitor)
+    await testUtils.app.init()
+    await testUtils.app.boot()
+    await testUtils.boot()
+
+    const ctx = await testUtils.createHttpContext()
+    const validator = vine.compile(
+      vine.object({
+        username: vine.string(),
+      })
+    )
+
+    ctx.request.setInitialBody({ error: true })
+
+    RequestValidator.messagesProvider = () =>
+      new SimpleMessagesProvider(
+        {
+          required: 'The value is missing',
+        },
+        {}
+      )
+    cleanup(() => {
+      RequestValidator.messagesProvider = undefined
+    })
+
+    const [error, data] = await ctx.request.tryValidateUsing(validator)
+
+    assert.isNull(data)
+    assert.instanceOf(error, ValidationError)
+    assert.deepEqual(error!.messages, [
+      {
+        field: 'username',
+        message: 'The value is missing',
+        rule: 'required',
+      },
+    ])
+  })
+
+  test('try validate using with custom error reporter', async ({ assert, cleanup }) => {
+    assert.plan(3)
+
+    const ignitor = new IgnitorFactory()
+      .withCoreConfig()
+      .merge({
+        rcFileContents: {
+          providers: [
+            () => import('../providers/app_provider.js'),
+            () => import('../providers/vinejs_provider.js'),
+          ],
+        },
+      })
+      .create(BASE_URL)
+
+    const testUtils = new TestUtilsFactory().create(ignitor)
+    await testUtils.app.init()
+    await testUtils.app.boot()
+    await testUtils.boot()
+
+    const ctx = await testUtils.createHttpContext()
+    const validator = vine.compile(
+      vine.object({
+        username: vine.string(),
+      })
+    )
+
+    ctx.request.setInitialBody({ error: true })
+
+    class MyErrorReporter extends SimpleErrorReporter {
+      report(
+        message: string,
+        rule: string,
+        field: FieldContext,
+        meta?: Record<string, any> | undefined
+      ): void {
+        return super.report(message, `validations.${rule}`, field, meta)
+      }
+    }
+
+    RequestValidator.errorReporter = () => {
+      return new MyErrorReporter()
+    }
+    cleanup(() => {
+      RequestValidator.errorReporter = undefined
+    })
+
+    const [error, data] = await ctx.request.tryValidateUsing(validator)
+
+    assert.isNull(data)
+    assert.instanceOf(error, ValidationError)
+    assert.deepEqual(error!.messages, [
+      {
+        field: 'username',
+        message: 'The username field must be defined',
+        rule: 'validations.required',
+      },
+    ])
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

I didn't create an issue first, but this was a feature added in [Vine.js back in June 2024](https://github.com/vinejs/vine/releases/tag/v2.1.0).
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Sometimes when validating requests, you just want to attempt to validate the request, but then handle the errors yourself, instead of having them propagate upwards out of your controller.

This adds support for `validator.tryValidate` from Vine.js to the `HttpRequest` as `tryValidateUsing`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

This will require a documentation change, if we agree this is a good feature to have.