### PR TITLE
feat(i18n): add command to publish localization templates

### DIFF
--- a/commands/lang/publish.ts
+++ b/commands/lang/publish.ts
@@ -1,0 +1,64 @@
+/*
+ * @adonisjs/core
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { BaseCommand } from '../../modules/ace/main.js'
+import { writeFile, readFile } from 'fs/promises'
+import { existsSync } from 'fs'
+
+/**
+ * Publish localization templates
+ */
+export default class MakeCommand extends BaseCommand {
+  static commandName = 'lang:publish'
+  static description = 'Eject localization templates to resources/lang/en directory'
+
+  async run() {
+    let messages: any = {}
+    try {
+      const vine = await import('@vinejs/vine/defaults')
+      messages = vine.messages
+    } catch {
+      this.logger.error('Vine is not installed. No localization templates to publish.')
+      return
+    }
+
+    const destination = this.app.languageFilesPath('en', 'validator.json')
+
+    let validatorMessages = {
+      shared: {
+        messages: {},
+      },
+    }
+
+    if (existsSync(destination)) {
+      try {
+        validatorMessages = JSON.parse(await readFile(destination, 'utf-8'))
+      } catch {
+        this.logger.warning(
+          'Failed to parse existing validator.json. Overwriting with default contents.'
+        )
+      }
+    }
+
+    validatorMessages = {
+      ...validatorMessages,
+      shared: {
+        ...validatorMessages.shared,
+        messages: {
+          ...messages,
+          ...validatorMessages.shared?.messages,
+        },
+      },
+    }
+
+    await writeFile(destination, JSON.stringify(validatorMessages, null, 2))
+
+    this.logger.success('Localization template published to resources/lang/en/validator.json')
+  }
+}

--- a/commands/lang/publish.ts
+++ b/commands/lang/publish.ts
@@ -8,8 +8,8 @@
  */
 
 import { BaseCommand } from '../../modules/ace/main.js'
-import { writeFile, readFile } from 'fs/promises'
-import { existsSync } from 'fs'
+import { writeFile, readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
 
 /**
  * Publish localization templates

--- a/commands/lang/publish.ts
+++ b/commands/lang/publish.ts
@@ -8,8 +8,9 @@
  */
 
 import { BaseCommand, flags } from '../../modules/ace/main.js'
-import { writeFile, readFile } from 'node:fs/promises'
+import { writeFile, readFile, mkdir } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
+import { dirname } from 'node:path'
 
 /**
  * Publish localization templates
@@ -71,6 +72,7 @@ export default class MakeCommand extends BaseCommand {
       },
     }
 
+    await mkdir(dirname(destination), { recursive: true })
     await writeFile(destination, JSON.stringify(validatorMessages, null, 2))
 
     this.logger.success('Localization template published to resources/lang/en/validator.json')

--- a/commands/lang/publish.ts
+++ b/commands/lang/publish.ts
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-import { BaseCommand } from '../../modules/ace/main.js'
+import { BaseCommand, flags } from '../../modules/ace/main.js'
 import { writeFile, readFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 
@@ -18,17 +18,29 @@ export default class MakeCommand extends BaseCommand {
   static commandName = 'lang:publish'
   static description = 'Eject localization templates to resources/lang/en directory'
 
+  @flags.boolean({ description: 'Merge with existing "validator.json" file' })
+  declare merge?: boolean
+
   async run() {
     let messages: any = {}
     try {
       const vine = await import('@vinejs/vine/defaults')
       messages = vine.messages
     } catch {
+      this.exitCode = 1
       this.logger.error('Vine is not installed. No localization templates to publish.')
       return
     }
 
     const destination = this.app.languageFilesPath('en', 'validator.json')
+
+    if (existsSync(destination) && !this.merge) {
+      this.exitCode = 1
+      this.logger.error(
+        'File "resources/lang/en/validator.json" already exists. Use "--merge" flag to update the file'
+      )
+      return
+    }
 
     let validatorMessages = {
       shared: {
@@ -40,9 +52,11 @@ export default class MakeCommand extends BaseCommand {
       try {
         validatorMessages = JSON.parse(await readFile(destination, 'utf-8'))
       } catch {
-        this.logger.warning(
+        this.exitCode = 1
+        this.logger.error(
           'Failed to parse existing validator.json. Overwriting with default contents.'
         )
+        return
       }
     }
 

--- a/tests/commands/lang_publish.spec.ts
+++ b/tests/commands/lang_publish.spec.ts
@@ -69,10 +69,6 @@ test.group('Lang publish', () => {
 
     const json = await fs.contentsJson('resources/lang/en/validator.json')
     assert.property(json, 'other')
-    // Existing message should be preserved/override vine message if same key,
-    // OR vine message merged?
-    // Code says: ...messages, ...validatorMessages.shared?.messages
-    // So existing messages (validatorMessages.shared.messages) take precedence over vine (messages).
     assert.equal(json.shared.messages.required, 'foo')
 
     assert.deepEqual(ace.ui.logger.getLogs(), [

--- a/tests/commands/lang_publish.spec.ts
+++ b/tests/commands/lang_publish.spec.ts
@@ -1,0 +1,78 @@
+
+import { test } from '@japa/runner'
+import { AceFactory } from '../../factories/core/ace.js'
+import LangPublishCommand from '../../commands/lang/publish.js'
+
+test.group('Lang publish', () => {
+  test('publish validator messages', async ({ assert, fs }) => {
+    const ace = await new AceFactory().make(fs.baseUrl)
+    await ace.app.init()
+    ace.ui.switchMode('raw')
+
+    const command = await ace.create(LangPublishCommand, [])
+    await command.exec()
+
+    await assert.fileExists('resources/lang/en/validator.json')
+    const json = await fs.contentsJson('resources/lang/en/validator.json')
+    assert.isObject(json.shared)
+    assert.isObject(json.shared.messages)
+    assert.isTrue(Object.keys(json.shared.messages).length > 0)
+
+    assert.deepEqual(ace.ui.logger.getLogs(), [
+      {
+        message: '[ green(success) ] Localization template published to resources/lang/en/validator.json',
+        stream: 'stdout',
+      },
+    ])
+  })
+
+  test('skip when validator messages file already exists', async ({ assert, fs }) => {
+    const ace = await new AceFactory().make(fs.baseUrl)
+    await ace.app.init()
+    ace.ui.switchMode('raw')
+
+    await fs.create('resources/lang/en/validator.json', JSON.stringify({ old: true }))
+
+    const command = await ace.create(LangPublishCommand, [])
+    await command.exec()
+
+    const json = await fs.contentsJson('resources/lang/en/validator.json')
+    assert.deepEqual(json, { old: true })
+
+    assert.deepEqual(ace.ui.logger.getLogs(), [
+      {
+        message: '[ red(error) ] File "resources/lang/en/validator.json" already exists. Use "--merge" flag to update the file',
+        stream: 'stderr',
+      },
+    ])
+  })
+
+  test('merge when validator messages file already exists and --merge is used', async ({ assert, fs }) => {
+    const ace = await new AceFactory().make(fs.baseUrl)
+    await ace.app.init()
+    ace.ui.switchMode('raw')
+
+    await fs.create('resources/lang/en/validator.json', JSON.stringify({
+      shared: { messages: { required: 'foo' } },
+      other: true
+    }))
+
+    const command = await ace.create(LangPublishCommand, ['--merge'])
+    await command.exec()
+
+    const json = await fs.contentsJson('resources/lang/en/validator.json')
+    assert.property(json, 'other')
+    // Existing message should be preserved/override vine message if same key,
+    // OR vine message merged?
+    // Code says: ...messages, ...validatorMessages.shared?.messages
+    // So existing messages (validatorMessages.shared.messages) take precedence over vine (messages).
+    assert.equal(json.shared.messages.required, 'foo')
+
+    assert.deepEqual(ace.ui.logger.getLogs(), [
+      {
+        message: '[ green(success) ] Localization template published to resources/lang/en/validator.json',
+        stream: 'stdout',
+      },
+    ])
+  })
+})

--- a/tests/commands/lang_publish.spec.ts
+++ b/tests/commands/lang_publish.spec.ts
@@ -1,4 +1,3 @@
-
 import { test } from '@japa/runner'
 import { AceFactory } from '../../factories/core/ace.js'
 import LangPublishCommand from '../../commands/lang/publish.js'
@@ -20,7 +19,8 @@ test.group('Lang publish', () => {
 
     assert.deepEqual(ace.ui.logger.getLogs(), [
       {
-        message: '[ green(success) ] Localization template published to resources/lang/en/validator.json',
+        message:
+          '[ green(success) ] Localization template published to resources/lang/en/validator.json',
         stream: 'stdout',
       },
     ])
@@ -41,21 +41,28 @@ test.group('Lang publish', () => {
 
     assert.deepEqual(ace.ui.logger.getLogs(), [
       {
-        message: '[ red(error) ] File "resources/lang/en/validator.json" already exists. Use "--merge" flag to update the file',
+        message:
+          '[ red(error) ] File "resources/lang/en/validator.json" already exists. Use "--merge" flag to update the file',
         stream: 'stderr',
       },
     ])
   })
 
-  test('merge when validator messages file already exists and --merge is used', async ({ assert, fs }) => {
+  test('merge when validator messages file already exists and --merge is used', async ({
+    assert,
+    fs,
+  }) => {
     const ace = await new AceFactory().make(fs.baseUrl)
     await ace.app.init()
     ace.ui.switchMode('raw')
 
-    await fs.create('resources/lang/en/validator.json', JSON.stringify({
-      shared: { messages: { required: 'foo' } },
-      other: true
-    }))
+    await fs.create(
+      'resources/lang/en/validator.json',
+      JSON.stringify({
+        shared: { messages: { required: 'foo' } },
+        other: true,
+      })
+    )
 
     const command = await ace.create(LangPublishCommand, ['--merge'])
     await command.exec()
@@ -70,7 +77,8 @@ test.group('Lang publish', () => {
 
     assert.deepEqual(ace.ui.logger.getLogs(), [
       {
-        message: '[ green(success) ] Localization template published to resources/lang/en/validator.json',
+        message:
+          '[ green(success) ] Localization template published to resources/lang/en/validator.json',
         stream: 'stdout',
       },
     ])


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

#5035 

Inspired by Laravel's `php artisan lang:publish` command. Eject translation template of built-in validation messages to `/resources/lang/en/validator.json`.

Not sure if this command should be included in core or i18n.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
