### PR TITLE
Index entities custom inertia middleware

### DIFF
--- a/src/assembler_hooks/index_entities.ts
+++ b/src/assembler_hooks/index_entities.ts
@@ -82,6 +82,7 @@ export function indexEntities(entities: IndexEntitiesConfig = {}) {
       source: 'app/transformers',
       importAlias: '#transformers',
       withSharedProps: false,
+      inertiaMiddlewareImportPath: '#middleware/inertia_middleware',
       skipSegments: ['transformers'],
       output: '.adonisjs/client/data.d.ts',
     },
@@ -166,7 +167,12 @@ export function indexEntities(entities: IndexEntitiesConfig = {}) {
               },
               transformValue: helpers.toImportPath,
             })
-            outputTransformerDataObjects(transformersList, buffer, transformers.withSharedProps)
+            outputTransformerDataObjects(
+              transformersList,
+              buffer,
+              transformers.withSharedProps,
+              transformers.inertiaMiddlewareImportPath
+            )
           },
           importAlias: transformers.importAlias,
           output: transformers.output,

--- a/src/assembler_hooks/index_entities.ts
+++ b/src/assembler_hooks/index_entities.ts
@@ -31,6 +31,11 @@ import { outputTransformerDataObjects } from '../utils.ts'
  *     source: 'app/custom-events',
  *     importAlias: '#custom-events'
  *   },
+ *   assemblers: {
+ *     enabled: true,
+ *     withSharedProps: true,
+ *     inertiaMiddlewareImportPath: '#middleware/inertia_middleware'
+ *   },
  *   controllers: {
  *     enabled: false
  *   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -353,6 +353,7 @@ export type IndexEntitiesConfig = {
     enabled?: boolean
     /** Whether to include shared props in transformers */
     withSharedProps?: boolean
+    inertiaMiddlewareImportPath?: string
     /** Source directory for transformers */
     source?: string
     /** Import alias for transformers */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -84,7 +84,8 @@ export async function importTypeScript(
 export async function outputTransformerDataObjects(
   transformersList: RecursiveFileTree,
   buffer: Assembler.FileBuffer,
-  withSharedProps: boolean
+  withSharedProps: boolean,
+  inertiaMiddlewareImportPath: string = '#middleware/inertia_middleware'
 ) {
   const importsBuffer = buffer.create()
   importsBuffer.write(`/// <reference path="./manifest.d.ts" />`)
@@ -128,7 +129,7 @@ export async function outputTransformerDataObjects(
   generateNamespaceTree(transformersList, [])
 
   if (withSharedProps) {
-    importsBuffer.write(`import type InertiaMiddleware from '#middleware/inertia_middleware'`)
+    importsBuffer.write(`import type InertiaMiddleware from '${inertiaMiddlewareImportPath}'`)
     buffer.write('export type SharedProps = InferSharedProps<InertiaMiddleware>')
   }
 

--- a/tests/index_generator.spec.ts
+++ b/tests/index_generator.spec.ts
@@ -246,6 +246,68 @@ test.group('Index generator', () => {
     )
   })
 
+  test('generate transformers index with shared props and custom inertia middleware import path', async ({
+    assert,
+    fs,
+  }) => {
+    const cliUi = Kernel.create().ui
+    cliUi.switchMode('raw')
+
+    await fs.create('app/transformers/user_transformer.ts', '')
+    await fs.create('app/transformers/blog/post_transformer.ts', '')
+
+    const generator = new IndexGenerator(stringHelpers.toUnixSlash(fs.basePath), cliUi.logger)
+    const indexer = indexEntities({
+      controllers: {
+        enabled: false,
+      },
+      events: {
+        enabled: false,
+      },
+      listeners: {
+        enabled: false,
+      },
+      transformers: {
+        enabled: true,
+        withSharedProps: true,
+        inertiaMiddlewareImportPath: '#core/middleware/inertia_middleware',
+      },
+    })
+
+    indexer.run({} as any, {} as any, generator)
+    await generator.generate()
+
+    await assert.fileExists('.adonisjs/client/data.d.ts')
+    assert.snapshot(await fs.contents('.adonisjs/client/data.d.ts')).matchInline(`
+      "/// <reference path=\\"./manifest.d.ts\\" />
+      import type { InferData, InferVariants } from '@adonisjs/core/types/transformers'
+      import type { InferSharedProps } from '@adonisjs/inertia/types'
+      import type BlogPostTransformer from '#transformers/blog/post_transformer'
+      import type UserTransformer from '#transformers/user_transformer'
+      import type InertiaMiddleware from '#core/middleware/inertia_middleware'
+
+      export namespace Data {
+        export namespace Blog {
+          export type Post = InferData<BlogPostTransformer>
+          export namespace Post {
+            export type Variants = InferVariants<BlogPostTransformer>
+          }
+        }
+        export type User = InferData<UserTransformer>
+        export namespace User {
+          export type Variants = InferVariants<UserTransformer>
+        }
+        export type SharedProps = InferSharedProps<InertiaMiddleware>
+      }
+      "
+    `)
+    assert.isDefined(
+      cliUi.logger
+        .getLogs()
+        .find(({ message }) => message.includes('[ blue(info) ] codegen: created'))
+    )
+  })
+
   test('generate transformers index with deeply nested directories', async ({ assert, fs }) => {
     const cliUi = Kernel.create().ui
     cliUi.switchMode('raw')


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
[https://github.com/orgs/adonisjs/discussions/5047](https://github.com/orgs/adonisjs/discussions/5047)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The problem is that, with the new entities index generator, when using shared props for Inertia, the Inertia middleware import path is a constant value that is not customizable. That means if you change the code architecture, it will break the autocompletion for Inertia shared props.

The goal, then, is to add a customizable import path for the Inertia middleware.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
