### PR TITLE
fix: replace vine.compile with vine.create in validator stub

### DIFF
--- a/stubs/make/validator/resource.stub
+++ b/stubs/make/validator/resource.stub
@@ -13,7 +13,7 @@ import vine from '@vinejs/vine'
  * Validator to validate the payload when creating
  * a new {{ validatorName }}.
  */
-export const {{ createAction }} = vine.compile(
+export const {{ createAction }} = vine.create(
   vine.object({})
 )
 
@@ -21,6 +21,6 @@ export const {{ createAction }} = vine.compile(
  * Validator to validate the payload when updating
  * an existing {{ validatorName }}.
  */
-export const {{ updateAction }} = vine.compile(
+export const {{ updateAction }} = vine.create(
   vine.object({})
 )

--- a/stubs/make/validator/resource.stub
+++ b/stubs/make/validator/resource.stub
@@ -13,14 +13,10 @@ import vine from '@vinejs/vine'
  * Validator to validate the payload when creating
  * a new {{ validatorName }}.
  */
-export const {{ createAction }} = vine.create(
-  vine.object({})
-)
+export const {{ createAction }} = vine.create({})
 
 /**
  * Validator to validate the payload when updating
  * an existing {{ validatorName }}.
  */
-export const {{ updateAction }} = vine.create(
-  vine.object({})
-)
+export const {{ updateAction }} = vine.create({})


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Simply update the validator stub using the new VineJS syntax. Replace ``vine.compile`` with ``vine.create``.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
